### PR TITLE
Sort days of week before calculating the step

### DIFF
--- a/lib/calendar_recurrence/rrule.ex
+++ b/lib/calendar_recurrence/rrule.ex
@@ -105,6 +105,7 @@ defmodule CalendarRecurrence.RRULE do
   defp step(%RRULE{freq: :weekly, byday: [], interval: interval}), do: 7 * interval
 
   defp step(%RRULE{freq: :weekly, byday: days_of_week, interval: interval}) do
+    days_of_week = Enum.sort(days_of_week)
     fn current ->
       current_day_of_week = Date.day_of_week(current)
       next_day_of_week = Enum.find(days_of_week, &(&1 > current_day_of_week))


### PR DESCRIPTION
Without sorting the days, the step calculation is wrong for RRULE `"FREQ=WEEKLY;COUNT=4;BYDAY=SU,MO"` because the resulting `bydays` list is `[7, 2]`.