### PR TITLE
Fix return value in enum implementation

### DIFF
--- a/lib/calendar_recurrence.ex
+++ b/lib/calendar_recurrence.ex
@@ -77,7 +77,7 @@ defmodule CalendarRecurrence do
         next = CalendarRecurrence.T.add(current, step(recurrence, current), recurrence.unit)
         do_reduce(next, count + 1, recurrence, fun.(current, acc), fun)
       else
-        {:halt, acc}
+        {:halted, acc}
       end
     end
 

--- a/test/calendar_recurrence_test.exs
+++ b/test/calendar_recurrence_test.exs
@@ -1,4 +1,5 @@
 defmodule CalendarRecurrenceTest do
+  alias CalendarRecurrence.RRULE
   use ExUnit.Case, async: true
   doctest CalendarRecurrence
 
@@ -6,6 +7,12 @@ defmodule CalendarRecurrenceTest do
     recurrence = CalendarRecurrence.new(start: ~D[2018-01-01])
 
     assert Enum.take(recurrence, 3) == [
+             ~D[2018-01-01],
+             ~D[2018-01-02],
+             ~D[2018-01-03]
+           ]
+
+    assert Stream.take(recurrence, 3) |> Enum.to_list() == [
              ~D[2018-01-01],
              ~D[2018-01-02],
              ~D[2018-01-03]
@@ -22,6 +29,27 @@ defmodule CalendarRecurrenceTest do
              ~U[2018-01-01 10:00:00Z],
              ~U[2018-01-02 10:00:00Z],
              ~U[2018-01-03 10:00:00Z]
+           ]
+
+    assert Stream.take(recurrence, 3) |> Enum.to_list() == [
+             ~U[2018-01-01 10:00:00Z],
+             ~U[2018-01-02 10:00:00Z],
+             ~U[2018-01-03 10:00:00Z]
+           ]
+
+    recurrence = RRULE.to_recurrence(%RRULE{freq: :daily, count: 3}, ~U[2019-01-01 10:50:00Z])
+
+    assert recurrence
+           |> Stream.take_while(fn occurrence ->
+             DateTime.compare(~U[2019-01-05 10:00:00Z], occurrence) in [:gt, :eq]
+           end)
+           |> Stream.filter(fn occurence ->
+             DateTime.compare(~U[2019-01-01 10:00:00Z], occurence) in [:lt, :eq]
+           end)
+           |> Enum.to_list() == [
+             ~U[2019-01-01 10:50:00Z],
+             ~U[2019-01-02 10:50:00Z],
+             ~U[2019-01-03 10:50:00Z]
            ]
   end
 


### PR DESCRIPTION
The return value for `Enumerable.reduce/3` should be `Enumerable.result`. This means we have to return `{:halted, acc}` instead of `{:halt, acc}`.

It is relevant when using `take_while` implementations.

I've added some tests, to make sure, Streams work as well.