### PR TITLE
fix typespecs in `rrule.ex`

### DIFF
--- a/lib/calendar_recurrence/rrule.ex
+++ b/lib/calendar_recurrence/rrule.ex
@@ -22,7 +22,7 @@ defmodule CalendarRecurrence.RRULE do
   # wkst: nil
 
   @type t() :: %__MODULE__{
-          freq: :daily,
+          freq: :weekly | :daily | :hourly | :minutely | :secondly | nil,
           interval: pos_integer(),
           until: CalendarRecurrence.date() | nil,
           count: non_neg_integer() | nil


### PR DESCRIPTION
The typespecs were missing the atoms for the frequency options