### PR TITLE
feat: CalendarRecurrence.RRULE add monthly `BYDAY` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # CHANGELOG
 
-## Unreleased
-
-- [CalendarRecurrence.RRULE](https://hexdocs.pm/calendar_recurrence/CalendarRecurrence.RRULE.html) add monthly `BYDAY` support with optional ordinal prefixes (#13). Enables rules like `FREQ=MONTHLY;BYDAY=1MO` (first Monday of every month) and `FREQ=MONTHLY;BYDAY=-1FR` (last Friday of every month). Plain `BYDAY` in monthly context (e.g., `BYDAY=MO` — every Monday of every month) is also supported (#19).
-
 ## v0.2.0 (2025-11-12)
 
 - [CalendarRecurrence.RRULE](https://hexdocs.pm/calendar_recurrence/CalendarRecurrence.RRULE.html) add `String.Chars` protocol (#16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- [CalendarRecurrence.RRULE](https://hexdocs.pm/calendar_recurrence/CalendarRecurrence.RRULE.html) add monthly `BYDAY` support with optional ordinal prefixes (#13). Enables rules like `FREQ=MONTHLY;BYDAY=1MO` (first Monday of every month) and `FREQ=MONTHLY;BYDAY=-1FR` (last Friday of every month). Plain `BYDAY` in monthly context (e.g., `BYDAY=MO` — every Monday of every month) is also supported.
+
 ## v0.2.0 (2025-11-12)
 
 - [CalendarRecurrence.RRULE](https://hexdocs.pm/calendar_recurrence/CalendarRecurrence.RRULE.html) add `String.Chars` protocol (#16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- [CalendarRecurrence.RRULE](https://hexdocs.pm/calendar_recurrence/CalendarRecurrence.RRULE.html) add monthly `BYDAY` support with optional ordinal prefixes (#13). Enables rules like `FREQ=MONTHLY;BYDAY=1MO` (first Monday of every month) and `FREQ=MONTHLY;BYDAY=-1FR` (last Friday of every month). Plain `BYDAY` in monthly context (e.g., `BYDAY=MO` — every Monday of every month) is also supported.
+- [CalendarRecurrence.RRULE](https://hexdocs.pm/calendar_recurrence/CalendarRecurrence.RRULE.html) add monthly `BYDAY` support with optional ordinal prefixes (#13). Enables rules like `FREQ=MONTHLY;BYDAY=1MO` (first Monday of every month) and `FREQ=MONTHLY;BYDAY=-1FR` (last Friday of every month). Plain `BYDAY` in monthly context (e.g., `BYDAY=MO` — every Monday of every month) is also supported (#19).
 
 ## v0.2.0 (2025-11-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- [CalendarRecurrence.RRULE](https://hexdocs.pm/calendar_recurrence/CalendarRecurrence.RRULE.html) add monthly `BYDAY` support with optional ordinal prefixes (#13). Enables rules like `FREQ=MONTHLY;BYDAY=1MO` (first Monday of every month) and `FREQ=MONTHLY;BYDAY=-1FR` (last Friday of every month). Plain `BYDAY` in monthly context (e.g., `BYDAY=MO` — every Monday of every month) is also supported.
+- [CalendarRecurrence.RRULE](https://hexdocs.pm/calendar_recurrence/CalendarRecurrence.RRULE.html) add monthly `BYDAY` support with optional ordinal prefixes (#13). Enables rules like `FREQ=MONTHLY;BYDAY=1MO` (first Monday of every month) and `FREQ=MONTHLY;BYDAY=-1FR` (last Friday of every month). Plain `BYDAY` in monthly context (e.g., `BYDAY=MO` — every Monday of every month) is also supported. (#19)
 
 ## v0.2.0 (2025-11-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- [CalendarRecurrence.RRULE](https://hexdocs.pm/calendar_recurrence/CalendarRecurrence.RRULE.html) add monthly `BYDAY` support with optional ordinal prefixes (#13). Enables rules like `FREQ=MONTHLY;BYDAY=1MO` (first Monday of every month) and `FREQ=MONTHLY;BYDAY=-1FR` (last Friday of every month). Plain `BYDAY` in monthly context (e.g., `BYDAY=MO` — every Monday of every month) is also supported. (#19)
+- [CalendarRecurrence.RRULE](https://hexdocs.pm/calendar_recurrence/CalendarRecurrence.RRULE.html) add monthly `BYDAY` support with optional ordinal prefixes (#13). Enables rules like `FREQ=MONTHLY;BYDAY=1MO` (first Monday of every month) and `FREQ=MONTHLY;BYDAY=-1FR` (last Friday of every month). Plain `BYDAY` in monthly context (e.g., `BYDAY=MO` — every Monday of every month) is also supported.
 
 ## v0.2.0 (2025-11-12)
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ iex> RRULE.to_recurrence("FREQ=WEEKLY;COUNT=4;BYDAY=MO,WE", ~D[2018-01-01]) |> E
 [~D[2018-01-01], ~D[2018-01-03], ~D[2018-01-08], ~D[2018-01-10]]
 ```
 
+Monthly BYDAY with ordinal prefixes is supported per RFC 5545. For example, "first Monday of every month":
+
+```elixir
+iex> RRULE.to_recurrence("FREQ=MONTHLY;BYDAY=1MO", ~D[2024-01-01]) |> Enum.take(4)
+[~D[2024-01-01], ~D[2024-02-05], ~D[2024-03-04], ~D[2024-04-01]]
+```
+
+Negative ordinals count from the end of the month. "Last Friday of every month":
+
+```elixir
+iex> RRULE.to_recurrence("FREQ=MONTHLY;BYDAY=-1FR", ~D[2024-01-26]) |> Enum.take(4)
+[~D[2024-01-26], ~D[2024-02-23], ~D[2024-03-29], ~D[2024-04-26]]
+```
+
 It also implements the `String.Chars` protocol:
 
 ```elixir

--- a/lib/calendar_recurrence/rrule.ex
+++ b/lib/calendar_recurrence/rrule.ex
@@ -135,7 +135,7 @@ defmodule CalendarRecurrence.RRULE do
 
   defp convert_date_type(%RRULE{until: until}, _), do: until
 
-  defp step(%RRULE{freq: :monthly, bymonthday: [], bymonth: months})
+  defp step(%RRULE{freq: :monthly, byday: [], bymonthday: [], bymonth: months})
        when is_list(months) and length(months) > 0 do
     months = Enum.sort(months)
 
@@ -165,7 +165,7 @@ defmodule CalendarRecurrence.RRULE do
     end
   end
 
-  defp step(%RRULE{freq: :monthly, bymonthday: days, bymonth: months})
+  defp step(%RRULE{freq: :monthly, byday: [], bymonthday: days, bymonth: months})
        when is_list(days) and is_list(months) and length(months) > 0 do
     months = Enum.sort(months)
     days = List.first(days)
@@ -196,7 +196,41 @@ defmodule CalendarRecurrence.RRULE do
     end
   end
 
-  defp step(%RRULE{freq: :monthly, interval: interval, bymonthday: []}) do
+  # Monthly BYDAY with ordinal prefixes (e.g., BYDAY=1MO,-1FR)
+  defp step(%RRULE{
+         freq: :monthly,
+         interval: interval,
+         byday: [{_, _} | _] = byday,
+         bymonthday: []
+       }) do
+    fn
+      %DateTime{} = current ->
+        next = next_monthly_ordinal_byday(current, byday, interval)
+        DateTime.diff(next, current, :second)
+
+      current ->
+        next = next_monthly_ordinal_byday(current, byday, interval)
+        Date.diff(next, current)
+    end
+  end
+
+  # Monthly BYDAY without ordinals (e.g., BYDAY=MO — every Monday of every month)
+  defp step(%RRULE{freq: :monthly, interval: interval, byday: [d | _] = byday, bymonthday: []})
+       when is_integer(d) do
+    days_of_week = Enum.sort(byday)
+
+    fn
+      %DateTime{} = current ->
+        next = next_monthly_plain_byday(current, days_of_week, interval)
+        DateTime.diff(next, current, :second)
+
+      current ->
+        next = next_monthly_plain_byday(current, days_of_week, interval)
+        Date.diff(next, current)
+    end
+  end
+
+  defp step(%RRULE{freq: :monthly, interval: interval, byday: [], bymonthday: []}) do
     fn
       %DateTime{} = current ->
         next = add_months(current, interval)
@@ -209,7 +243,8 @@ defmodule CalendarRecurrence.RRULE do
     end
   end
 
-  defp step(%RRULE{freq: :monthly, interval: interval, bymonthday: days}) when is_list(days) do
+  defp step(%RRULE{freq: :monthly, interval: interval, byday: [], bymonthday: days})
+       when is_list(days) do
     days = Enum.sort(days)
 
     fn
@@ -373,6 +408,107 @@ defmodule CalendarRecurrence.RRULE do
     end
   end
 
+  defp nth_weekday_of_month(year, month, weekday, ordinal) when ordinal > 0 do
+    first_day_dow = :calendar.day_of_the_week(year, month, 1)
+    days_until = rem(weekday - first_day_dow + 7, 7)
+    target_day = days_until + 1 + (ordinal - 1) * 7
+    last_day = :calendar.last_day_of_the_month(year, month)
+    if target_day <= last_day, do: target_day, else: nil
+  end
+
+  defp nth_weekday_of_month(year, month, weekday, ordinal) when ordinal < 0 do
+    last_day = :calendar.last_day_of_the_month(year, month)
+    last_day_dow = :calendar.day_of_the_week(year, month, last_day)
+    days_back = rem(last_day_dow - weekday + 7, 7)
+    last_occurrence = last_day - days_back
+    target_day = last_occurrence + (ordinal + 1) * 7
+    if target_day >= 1, do: target_day, else: nil
+  end
+
+  defp next_monthly_ordinal_byday(current, byday, interval) do
+    matching_days =
+      byday
+      |> Enum.map(fn {ordinal, weekday} ->
+        nth_weekday_of_month(current.year, current.month, weekday, ordinal)
+      end)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.filter(&(&1 > current.day))
+      |> Enum.sort()
+
+    case matching_days do
+      [next_day | _] ->
+        %{current | day: next_day}
+
+      [] ->
+        next_month_start = advance_month(current, interval)
+        find_first_ordinal_byday(next_month_start, byday, interval)
+    end
+  end
+
+  defp find_first_ordinal_byday(date, byday, interval) do
+    matching_days =
+      byday
+      |> Enum.map(fn {ordinal, weekday} ->
+        nth_weekday_of_month(date.year, date.month, weekday, ordinal)
+      end)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.sort()
+
+    case matching_days do
+      [first_day | _] ->
+        %{date | day: first_day}
+
+      [] ->
+        find_first_ordinal_byday(advance_month(date, interval), byday, interval)
+    end
+  end
+
+  defp next_monthly_plain_byday(current, days_of_week, interval) do
+    last_day = :calendar.last_day_of_the_month(current.year, current.month)
+    current_dow = :calendar.day_of_the_week(current.year, current.month, current.day)
+
+    candidates =
+      days_of_week
+      |> Enum.flat_map(fn dow ->
+        diff = rem(dow - current_dow + 7, 7)
+        diff = if diff == 0, do: 7, else: diff
+        next_day = current.day + diff
+        if next_day <= last_day, do: [next_day], else: []
+      end)
+      |> Enum.sort()
+
+    case candidates do
+      [next_day | _] ->
+        %{current | day: next_day}
+
+      [] ->
+        next_month_start = advance_month(current, interval)
+        find_first_plain_byday(next_month_start, days_of_week)
+    end
+  end
+
+  defp find_first_plain_byday(date, days_of_week) do
+    first_day_dow = :calendar.day_of_the_week(date.year, date.month, 1)
+
+    first_day =
+      days_of_week
+      |> Enum.map(fn dow ->
+        diff = rem(dow - first_day_dow + 7, 7)
+        diff + 1
+      end)
+      |> Enum.sort()
+      |> List.first()
+
+    %{date | day: first_day}
+  end
+
+  defp advance_month(date, interval) do
+    new_month = date.month + interval
+    years_to_add = div(new_month - 1, 12)
+    remaining_month = rem(new_month - 1, 12) + 1
+    %{date | year: date.year + years_to_add, month: remaining_month, day: 1}
+  end
+
   defimpl String.Chars do
     @doc """
     Converts `%RRULE{}` into a rrule string.
@@ -434,7 +570,13 @@ defmodule CalendarRecurrence.RRULE do
     end
 
     defp add_part(:byday = key, value) do
-      days = Enum.map_join(value, ",", fn day -> @weekdays[day] end)
+      days =
+        Enum.map_join(value, ",", fn
+          {ordinal, day} when ordinal > 0 -> "#{ordinal}#{@weekdays[day]}"
+          {ordinal, day} when ordinal < 0 -> "#{ordinal}#{@weekdays[day]}"
+          day -> @weekdays[day]
+        end)
+
       key_value(key, days)
     end
 

--- a/lib/calendar_recurrence/rrule.ex
+++ b/lib/calendar_recurrence/rrule.ex
@@ -61,7 +61,7 @@ defmodule CalendarRecurrence.RRULE do
   # wkst: nil
 
   @type t() :: %__MODULE__{
-          freq: :monthly | :weekly | :daily | :hourly | :minutely | :secondly | nil,
+          freq: :yearly | :monthly | :weekly | :daily | :hourly | :minutely | :secondly | nil,
           interval: pos_integer(),
           until: CalendarRecurrence.date() | nil,
           count: non_neg_integer() | nil
@@ -420,17 +420,7 @@ defmodule CalendarRecurrence.RRULE do
       DateTime.add(date, interval, :second) |> DateTime.diff(date, :second)
     end
 
-  defp add_months(%DateTime{} = date, interval) do
-    adjust_months(date, interval)
-  end
-
-  defp add_months(%Date{} = date, interval) do
-    adjust_months(date, interval)
-  end
-
-  defp add_months(%NaiveDateTime{} = date, interval) do
-    adjust_months(date, interval)
-  end
+  defp add_months(date, interval), do: adjust_months(date, interval)
 
   defp adjust_months(date, interval) do
     original_day = date.day
@@ -548,7 +538,12 @@ defmodule CalendarRecurrence.RRULE do
     end
   end
 
-  defp find_first_ordinal_byday(date, byday, interval) do
+  defp find_first_ordinal_byday(date, byday, interval, attempts \\ 0) do
+    if attempts >= 12 do
+      raise ArgumentError,
+            "no matching BYDAY occurrence found within 12 months of #{Date.to_iso8601(date)}"
+    end
+
     matching_days =
       byday
       |> Enum.map(fn {ordinal, weekday} ->
@@ -562,7 +557,7 @@ defmodule CalendarRecurrence.RRULE do
         %{date | day: first_day}
 
       [] ->
-        find_first_ordinal_byday(advance_month(date, interval), byday, interval)
+        find_first_ordinal_byday(advance_month(date, interval), byday, interval, attempts + 1)
     end
   end
 
@@ -632,7 +627,12 @@ defmodule CalendarRecurrence.RRULE do
     end
   end
 
-  defp find_first_yearly_ordinal_byday(current, year, months, byday, interval) do
+  defp find_first_yearly_ordinal_byday(current, year, months, byday, interval, attempts \\ 0) do
+    if attempts >= 10 do
+      raise ArgumentError,
+            "no matching yearly BYDAY occurrence found within 10 years of #{year}"
+    end
+
     matching_dates =
       for month <- months,
           {ordinal, weekday} <- byday,
@@ -647,7 +647,14 @@ defmodule CalendarRecurrence.RRULE do
         %{current | year: year, month: month, day: day}
 
       [] ->
-        find_first_yearly_ordinal_byday(current, year + interval, months, byday, interval)
+        find_first_yearly_ordinal_byday(
+          current,
+          year + interval,
+          months,
+          byday,
+          interval,
+          attempts + 1
+        )
     end
   end
 
@@ -714,8 +721,7 @@ defmodule CalendarRecurrence.RRULE do
     defp add_part(:byday = key, value) do
       days =
         Enum.map_join(value, ",", fn
-          {ordinal, day} when ordinal > 0 -> "#{ordinal}#{@weekdays[day]}"
-          {ordinal, day} when ordinal < 0 -> "#{ordinal}#{@weekdays[day]}"
+          {ordinal, day} -> "#{ordinal}#{@weekdays[day]}"
           day -> @weekdays[day]
         end)
 

--- a/lib/calendar_recurrence/rrule.ex
+++ b/lib/calendar_recurrence/rrule.ex
@@ -1,8 +1,47 @@
 defmodule CalendarRecurrence.RRULE do
   @moduledoc """
-  RRULE parser.
+  RFC 5545 RRULE parser and recurrence generator.
 
-  See https://tools.ietf.org/html/rfc5545#section-3.3.10
+  Parses RRULE strings into `%RRULE{}` structs, converts them back to strings
+  via `String.Chars`, and generates recurring date streams via `to_recurrence/2`.
+
+  ## Supported RRULE properties
+
+    * `FREQ` — `SECONDLY`, `MINUTELY`, `HOURLY`, `DAILY`, `WEEKLY`, `MONTHLY`
+    * `INTERVAL` — repeat interval (default 1)
+    * `COUNT` — maximum number of occurrences
+    * `UNTIL` — end date (Date, NaiveDateTime, or DateTime with `Z` suffix)
+    * `BYDAY` — day-of-week filter, with optional ordinal prefix for `MONTHLY`:
+      - Plain: `MO`, `TU`, `WE`, `TH`, `FR`, `SA`, `SU`
+      - Ordinal: `1MO` (first Monday), `-1FR` (last Friday), `+2SU` (second Sunday)
+    * `BYMONTHDAY` — day-of-month (1–31 or -1–-31 for counting from end)
+    * `BYMONTH` — month filter (1–12)
+    * `BYHOUR`, `BYMINUTE`, `BYSECOND` — time components
+
+  ## BYDAY with MONTHLY frequency
+
+  When `FREQ=MONTHLY`, `BYDAY` supports two modes:
+
+    * **With ordinal prefix** — selects a specific occurrence of a weekday in each
+      month. For example, `BYDAY=1MO` means "the first Monday of every month" and
+      `BYDAY=-1FR` means "the last Friday of every month". Months that lack the
+      requested occurrence (e.g., a 5th Monday) are skipped.
+
+    * **Without ordinal prefix** — selects every occurrence of the weekday in each
+      month. For example, `BYDAY=MO` means "every Monday of every month".
+
+  ## Examples
+
+      iex> RRULE.parse!("FREQ=MONTHLY;BYDAY=1MO")
+      %RRULE{freq: :monthly, byday: [{1, 1}]}
+
+      iex> RRULE.parse!("FREQ=MONTHLY;BYDAY=-1FR")
+      %RRULE{freq: :monthly, byday: [{-1, 5}]}
+
+      iex> to_string(%RRULE{freq: :monthly, byday: [{1, 1}]})
+      "FREQ=MONTHLY;BYDAY=1MO"
+
+  See <https://tools.ietf.org/html/rfc5545#section-3.3.10>
   """
 
   defstruct freq: nil,
@@ -29,8 +68,8 @@ defmodule CalendarRecurrence.RRULE do
           # bysecond: [0..59],
           # byminute: [0..59],
           # byhour: [0..59],
-          # byday: [1..31],
-          # bymonthday: ,
+          # byday: [1..7 | {integer(), 1..7}],
+          # bymonthday: [-31..-1 | 1..31],
           # byyearday: ,
           # byweekno:
           # bymonth: [1..12]
@@ -40,6 +79,27 @@ defmodule CalendarRecurrence.RRULE do
 
   alias __MODULE__
 
+  @doc """
+  Parses an RRULE string into a `%RRULE{}` struct.
+
+  ## Examples
+
+      iex> RRULE.parse("FREQ=DAILY;COUNT=10")
+      {:ok, %RRULE{freq: :daily, count: 10}}
+
+      iex> RRULE.parse("FREQ=WEEKLY;BYDAY=MO,TU")
+      {:ok, %RRULE{freq: :weekly, byday: [1, 2]}}
+
+      iex> RRULE.parse("FREQ=MONTHLY;BYDAY=1MO")
+      {:ok, %RRULE{freq: :monthly, byday: [{1, 1}]}}
+
+      iex> RRULE.parse("FREQ=MONTHLY;BYDAY=-1FR")
+      {:ok, %RRULE{freq: :monthly, byday: [{-1, 5}]}}
+
+  Weekdays are represented as integers 1 (Monday) through 7 (Sunday).
+  Ordinal BYDAY values are tuples `{ordinal, weekday}` where positive
+  ordinals count from the start of the month and negative from the end.
+  """
   @spec parse(String.t()) :: {:ok, t()} | {:error, term()}
   def parse(binary) do
     case CalendarRecurrence.RRULE.Parser.parse(binary) do
@@ -73,6 +133,9 @@ defmodule CalendarRecurrence.RRULE do
   @doc """
   Converts `rrule` into a recurrence starting at given `start` date.
 
+  Accepts an `%RRULE{}` struct or a raw RRULE string. The `start` date can be
+  a `Date`, `NaiveDateTime`, or `DateTime`.
+
   ## Examples
 
       iex> RRULE.to_recurrence(%RRULE{freq: :daily}, ~D[2018-01-01]) |> Enum.take(3)
@@ -80,6 +143,24 @@ defmodule CalendarRecurrence.RRULE do
         ~D[2018-01-01],
         ~D[2018-01-02],
         ~D[2018-01-03]
+      ]
+
+  First Monday of every month:
+
+      iex> RRULE.to_recurrence("FREQ=MONTHLY;BYDAY=1MO", ~D[2024-01-01]) |> Enum.take(3)
+      [
+        ~D[2024-01-01],
+        ~D[2024-02-05],
+        ~D[2024-03-04]
+      ]
+
+  Last Friday of every month:
+
+      iex> RRULE.to_recurrence("FREQ=MONTHLY;BYDAY=-1FR", ~D[2024-01-26]) |> Enum.take(3)
+      [
+        ~D[2024-01-26],
+        ~D[2024-02-23],
+        ~D[2024-03-29]
       ]
 
   """

--- a/lib/calendar_recurrence/rrule.ex
+++ b/lib/calendar_recurrence/rrule.ex
@@ -104,14 +104,10 @@ defmodule CalendarRecurrence.RRULE do
   def parse(binary) do
     case CalendarRecurrence.RRULE.Parser.parse(binary) do
       {:ok, [map], "", _, _, _} ->
-        if Map.has_key?(map, :freq) do
-          if Map.has_key?(map, :until) && Map.has_key?(map, :count) do
-            {:error, :until_or_count}
-          else
-            {:ok, struct!(__MODULE__, map)}
-          end
-        else
-          {:error, :missing_freq}
+        with :ok <- validate_freq(map),
+             :ok <- validate_until_count(map),
+             :ok <- validate_byday(map) do
+          {:ok, struct!(__MODULE__, map)}
         end
 
       {:ok, _, rest, _, _, _} ->
@@ -129,6 +125,46 @@ defmodule CalendarRecurrence.RRULE do
       {:error, reason} -> raise ArgumentError, "parse error: #{inspect(reason)}"
     end
   end
+
+  defp validate_freq(map) do
+    if Map.has_key?(map, :freq), do: :ok, else: {:error, :missing_freq}
+  end
+
+  defp validate_until_count(map) do
+    if Map.has_key?(map, :until) && Map.has_key?(map, :count),
+      do: {:error, :until_or_count},
+      else: :ok
+  end
+
+  defp validate_byday(%{byday: days}) do
+    Enum.reduce_while(days, :ok, fn
+      {ordinal, weekday}, :ok ->
+        cond do
+          weekday not in 1..7 ->
+            {:halt,
+             {:error,
+              "invalid BYDAY weekday #{weekday}, must be 1 (MO) through 7 (SU)"}}
+
+          ordinal == 0 or ordinal > 5 or ordinal < -5 ->
+            {:halt,
+             {:error,
+              "invalid BYDAY ordinal #{ordinal}, must be between -5 and 5 (excluding 0), e.g. 1MO (first Monday) or -1FR (last Friday)"}}
+
+          true ->
+            {:cont, :ok}
+        end
+
+      weekday, :ok when is_integer(weekday) ->
+        if weekday in 1..7,
+          do: {:cont, :ok},
+          else:
+            {:halt,
+             {:error,
+              "invalid BYDAY weekday #{weekday}, must be 1 (MO) through 7 (SU)"}}
+    end)
+  end
+
+  defp validate_byday(_map), do: :ok
 
   @doc """
   Converts `rrule` into a recurrence starting at given `start` date.
@@ -541,7 +577,7 @@ defmodule CalendarRecurrence.RRULE do
   defp find_first_ordinal_byday(date, byday, interval, attempts \\ 0) do
     if attempts >= 12 do
       raise ArgumentError,
-            "no matching BYDAY occurrence found within 12 months of #{Date.to_iso8601(date)}"
+            "no matching BYDAY occurrence found within #{12 * interval} months of #{Date.to_iso8601(date)}"
     end
 
     matching_days =

--- a/lib/calendar_recurrence/rrule.ex
+++ b/lib/calendar_recurrence/rrule.ex
@@ -339,6 +339,28 @@ defmodule CalendarRecurrence.RRULE do
     end
   end
 
+  # Yearly BYDAY with BYMONTH (e.g., FREQ=YEARLY;BYMONTH=3;BYDAY=2SU)
+  defp step(%RRULE{
+         freq: :yearly,
+         interval: interval,
+         bymonth: months,
+         byday: [{_, _} | _] = byday,
+         bymonthday: []
+       })
+       when is_list(months) and length(months) > 0 do
+    months = Enum.sort(months)
+
+    fn
+      %DateTime{} = current ->
+        next = next_yearly_ordinal_byday(current, months, byday, interval)
+        DateTime.diff(next, current, :second)
+
+      current ->
+        next = next_yearly_ordinal_byday(current, months, byday, interval)
+        Date.diff(next, current)
+    end
+  end
+
   defp step(%RRULE{freq: :weekly, byday: [], interval: interval}),
     do: fn
       %DateTime{} = date ->
@@ -588,6 +610,45 @@ defmodule CalendarRecurrence.RRULE do
     years_to_add = div(new_month - 1, 12)
     remaining_month = rem(new_month - 1, 12) + 1
     %{date | year: date.year + years_to_add, month: remaining_month, day: 1}
+  end
+
+  defp next_yearly_ordinal_byday(current, months, byday, interval) do
+    matching_dates =
+      for month <- months,
+          {ordinal, weekday} <- byday,
+          day = nth_weekday_of_month(current.year, month, weekday, ordinal),
+          day != nil,
+          month > current.month or (month == current.month and day > current.day) do
+        {month, day}
+      end
+      |> Enum.sort()
+
+    case matching_dates do
+      [{month, day} | _] ->
+        %{current | month: month, day: day}
+
+      [] ->
+        find_first_yearly_ordinal_byday(current, current.year + interval, months, byday, interval)
+    end
+  end
+
+  defp find_first_yearly_ordinal_byday(current, year, months, byday, interval) do
+    matching_dates =
+      for month <- months,
+          {ordinal, weekday} <- byday,
+          day = nth_weekday_of_month(year, month, weekday, ordinal),
+          day != nil do
+        {month, day}
+      end
+      |> Enum.sort()
+
+    case matching_dates do
+      [{month, day} | _] ->
+        %{current | year: year, month: month, day: day}
+
+      [] ->
+        find_first_yearly_ordinal_byday(current, year + interval, months, byday, interval)
+    end
   end
 
   defimpl String.Chars do

--- a/lib/calendar_recurrence/rrule.ex
+++ b/lib/calendar_recurrence/rrule.ex
@@ -141,9 +141,7 @@ defmodule CalendarRecurrence.RRULE do
       {ordinal, weekday}, :ok ->
         cond do
           weekday not in 1..7 ->
-            {:halt,
-             {:error,
-              "invalid BYDAY weekday #{weekday}, must be 1 (MO) through 7 (SU)"}}
+            {:halt, {:error, "invalid BYDAY weekday #{weekday}, must be 1 (MO) through 7 (SU)"}}
 
           ordinal == 0 or ordinal > 5 or ordinal < -5 ->
             {:halt,
@@ -158,9 +156,7 @@ defmodule CalendarRecurrence.RRULE do
         if weekday in 1..7,
           do: {:cont, :ok},
           else:
-            {:halt,
-             {:error,
-              "invalid BYDAY weekday #{weekday}, must be 1 (MO) through 7 (SU)"}}
+            {:halt, {:error, "invalid BYDAY weekday #{weekday}, must be 1 (MO) through 7 (SU)"}}
     end)
   end
 

--- a/lib/calendar_recurrence/rrule_parser.ex
+++ b/lib/calendar_recurrence/rrule_parser.ex
@@ -1,5 +1,5 @@
 # Generated from lib/calendar_recurrence/rrule_parser.ex.exs, do not edit.
-# Generated at 2026-02-18 22:55:22Z.
+# Generated at 2026-02-19 00:12:47Z.
 
 if Code.ensure_loaded?(NimbleParsec) do
   defmodule CalendarRecurrence.RRULE.ParserHelpers do

--- a/lib/calendar_recurrence/rrule_parser.ex
+++ b/lib/calendar_recurrence/rrule_parser.ex
@@ -1,5 +1,5 @@
 # Generated from lib/calendar_recurrence/rrule_parser.ex.exs, do not edit.
-# Generated at 2025-11-12 13:01:17Z.
+# Generated at 2026-02-18 22:55:22Z.
 
 if Code.ensure_loaded?(NimbleParsec) do
   defmodule CalendarRecurrence.RRULE.ParserHelpers do
@@ -92,7 +92,7 @@ defmodule CalendarRecurrence.RRULE.Parser do
   end
 
   defp parse__1(rest, acc, stack, context, line, offset) do
-    parse__116(rest, [], [{rest, context, line, offset}, acc | stack], context, line, offset)
+    parse__135(rest, [], [{rest, context, line, offset}, acc | stack], context, line, offset)
   end
 
   defp parse__3(
@@ -108,7 +108,7 @@ defmodule CalendarRecurrence.RRULE.Parser do
 
   defp parse__3(rest, _acc, _stack, context, line, offset) do
     {:error,
-     "expected string \"FREQ\", followed by string \"=\", followed by string \"SECONDLY\" or string \"MINUTELY\" or string \"HOURLY\" or string \"DAILY\" or string \"WEEKLY\" or string \"MONTHLY\" or string \"YEARLY\" or string \"UNTIL\", followed by string \"=\", followed by datetime or date or string \"COUNT\", followed by string \"=\", followed by ASCII character in the range \"0\" to \"9\", followed by ASCII character in the range \"0\" to \"9\" or string \"INTERVAL\", followed by string \"=\", followed by ASCII character in the range \"0\" to \"9\", followed by ASCII character in the range \"0\" to \"9\" or string \"BYSECOND\", followed by string \"=\", followed by string \"59\" or string \"58\" or string \"57\" or string \"56\" or string \"55\" or string \"54\" or string \"53\" or string \"52\" or string \"51\" or string \"50\" or string \"49\" or string \"48\" or string \"47\" or string \"46\" or string \"45\" or string \"44\" or string \"43\" or string \"42\" or string \"41\" or string \"40\" or string \"39\" or string \"38\" or string \"37\" or string \"36\" or string \"35\" or string \"34\" or string \"33\" or string \"32\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\", followed by ,, followed by string \"59\" or string \"58\" or string \"57\" or string \"56\" or string \"55\" or string \"54\" or string \"53\" or string \"52\" or string \"51\" or string \"50\" or string \"49\" or string \"48\" or string \"47\" or string \"46\" or string \"45\" or string \"44\" or string \"43\" or string \"42\" or string \"41\" or string \"40\" or string \"39\" or string \"38\" or string \"37\" or string \"36\" or string \"35\" or string \"34\" or string \"33\" or string \"32\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\" or string \"BYMINUTE\", followed by string \"=\", followed by string \"59\" or string \"58\" or string \"57\" or string \"56\" or string \"55\" or string \"54\" or string \"53\" or string \"52\" or string \"51\" or string \"50\" or string \"49\" or string \"48\" or string \"47\" or string \"46\" or string \"45\" or string \"44\" or string \"43\" or string \"42\" or string \"41\" or string \"40\" or string \"39\" or string \"38\" or string \"37\" or string \"36\" or string \"35\" or string \"34\" or string \"33\" or string \"32\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\", followed by ,, followed by string \"59\" or string \"58\" or string \"57\" or string \"56\" or string \"55\" or string \"54\" or string \"53\" or string \"52\" or string \"51\" or string \"50\" or string \"49\" or string \"48\" or string \"47\" or string \"46\" or string \"45\" or string \"44\" or string \"43\" or string \"42\" or string \"41\" or string \"40\" or string \"39\" or string \"38\" or string \"37\" or string \"36\" or string \"35\" or string \"34\" or string \"33\" or string \"32\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\" or string \"BYHOUR\", followed by string \"=\", followed by string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\", followed by ,, followed by string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\" or string \"BYDAY\", followed by string \"=\", followed by string \"SU\" or string \"MO\" or string \"TU\" or string \"WE\" or string \"TH\" or string \"FR\" or string \"SA\", followed by ,, followed by string \"SU\" or string \"MO\" or string \"TU\" or string \"WE\" or string \"TH\" or string \"FR\" or string \"SA\" or string \"BYDAY\", followed by string \"=\", followed by string \"SU\" or string \"MO\" or string \"TU\" or string \"WE\" or string \"TH\" or string \"FR\" or string \"SA\", followed by ,, followed by string \"SU\" or string \"MO\" or string \"TU\" or string \"WE\" or string \"TH\" or string \"FR\" or string \"SA\" or string \"BYMONTH\", followed by string \"=\", followed by string \"1\" or string \"2\" or string \"3\" or string \"4\" or string \"5\" or string \"6\" or string \"7\" or string \"8\" or string \"9\" or string \"10\" or string \"11\" or string \"12\", followed by ,, followed by string \"1\" or string \"2\" or string \"3\" or string \"4\" or string \"5\" or string \"6\" or string \"7\" or string \"8\" or string \"9\" or string \"10\" or string \"11\" or string \"12\" or string \"BYMONTHDAY\", followed by string \"=\", followed by string \"-31\" or string \"-30\" or string \"-29\" or string \"-28\" or string \"-27\" or string \"-26\" or string \"-25\" or string \"-24\" or string \"-23\" or string \"-22\" or string \"-21\" or string \"-20\" or string \"-19\" or string \"-18\" or string \"-17\" or string \"-16\" or string \"-15\" or string \"-14\" or string \"-13\" or string \"-12\" or string \"-11\" or string \"-10\" or string \"-9\" or string \"-8\" or string \"-7\" or string \"-6\" or string \"-5\" or string \"-4\" or string \"-3\" or string \"-2\" or string \"-1\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\", followed by ,, followed by string \"-31\" or string \"-30\" or string \"-29\" or string \"-28\" or string \"-27\" or string \"-26\" or string \"-25\" or string \"-24\" or string \"-23\" or string \"-22\" or string \"-21\" or string \"-20\" or string \"-19\" or string \"-18\" or string \"-17\" or string \"-16\" or string \"-15\" or string \"-14\" or string \"-13\" or string \"-12\" or string \"-11\" or string \"-10\" or string \"-9\" or string \"-8\" or string \"-7\" or string \"-6\" or string \"-5\" or string \"-4\" or string \"-3\" or string \"-2\" or string \"-1\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\"",
+     "expected string \"FREQ\", followed by string \"=\", followed by string \"SECONDLY\" or string \"MINUTELY\" or string \"HOURLY\" or string \"DAILY\" or string \"WEEKLY\" or string \"MONTHLY\" or string \"YEARLY\" or string \"UNTIL\", followed by string \"=\", followed by datetime or date or string \"COUNT\", followed by string \"=\", followed by ASCII character in the range \"0\" to \"9\", followed by ASCII character in the range \"0\" to \"9\" or string \"INTERVAL\", followed by string \"=\", followed by ASCII character in the range \"0\" to \"9\", followed by ASCII character in the range \"0\" to \"9\" or string \"BYSECOND\", followed by string \"=\", followed by string \"59\" or string \"58\" or string \"57\" or string \"56\" or string \"55\" or string \"54\" or string \"53\" or string \"52\" or string \"51\" or string \"50\" or string \"49\" or string \"48\" or string \"47\" or string \"46\" or string \"45\" or string \"44\" or string \"43\" or string \"42\" or string \"41\" or string \"40\" or string \"39\" or string \"38\" or string \"37\" or string \"36\" or string \"35\" or string \"34\" or string \"33\" or string \"32\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\", followed by ,, followed by string \"59\" or string \"58\" or string \"57\" or string \"56\" or string \"55\" or string \"54\" or string \"53\" or string \"52\" or string \"51\" or string \"50\" or string \"49\" or string \"48\" or string \"47\" or string \"46\" or string \"45\" or string \"44\" or string \"43\" or string \"42\" or string \"41\" or string \"40\" or string \"39\" or string \"38\" or string \"37\" or string \"36\" or string \"35\" or string \"34\" or string \"33\" or string \"32\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\" or string \"BYMINUTE\", followed by string \"=\", followed by string \"59\" or string \"58\" or string \"57\" or string \"56\" or string \"55\" or string \"54\" or string \"53\" or string \"52\" or string \"51\" or string \"50\" or string \"49\" or string \"48\" or string \"47\" or string \"46\" or string \"45\" or string \"44\" or string \"43\" or string \"42\" or string \"41\" or string \"40\" or string \"39\" or string \"38\" or string \"37\" or string \"36\" or string \"35\" or string \"34\" or string \"33\" or string \"32\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\", followed by ,, followed by string \"59\" or string \"58\" or string \"57\" or string \"56\" or string \"55\" or string \"54\" or string \"53\" or string \"52\" or string \"51\" or string \"50\" or string \"49\" or string \"48\" or string \"47\" or string \"46\" or string \"45\" or string \"44\" or string \"43\" or string \"42\" or string \"41\" or string \"40\" or string \"39\" or string \"38\" or string \"37\" or string \"36\" or string \"35\" or string \"34\" or string \"33\" or string \"32\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\" or string \"BYHOUR\", followed by string \"=\", followed by string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\", followed by ,, followed by string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\" or string \"BYDAY\", followed by string \"=\", followed by string \"-\" or string \"+\" or nothing, followed by ASCII character in the range \"0\" to \"9\", followed by ASCII character in the range \"0\" to \"9\", followed by string \"SU\" or string \"MO\" or string \"TU\" or string \"WE\" or string \"TH\" or string \"FR\" or string \"SA\" or string \"SU\" or string \"MO\" or string \"TU\" or string \"WE\" or string \"TH\" or string \"FR\" or string \"SA\", followed by ,, followed by string \"-\" or string \"+\" or nothing, followed by ASCII character in the range \"0\" to \"9\", followed by ASCII character in the range \"0\" to \"9\", followed by string \"SU\" or string \"MO\" or string \"TU\" or string \"WE\" or string \"TH\" or string \"FR\" or string \"SA\" or string \"SU\" or string \"MO\" or string \"TU\" or string \"WE\" or string \"TH\" or string \"FR\" or string \"SA\" or string \"BYMONTH\", followed by string \"=\", followed by string \"1\" or string \"2\" or string \"3\" or string \"4\" or string \"5\" or string \"6\" or string \"7\" or string \"8\" or string \"9\" or string \"10\" or string \"11\" or string \"12\", followed by ,, followed by string \"1\" or string \"2\" or string \"3\" or string \"4\" or string \"5\" or string \"6\" or string \"7\" or string \"8\" or string \"9\" or string \"10\" or string \"11\" or string \"12\" or string \"BYMONTHDAY\", followed by string \"=\", followed by string \"-31\" or string \"-30\" or string \"-29\" or string \"-28\" or string \"-27\" or string \"-26\" or string \"-25\" or string \"-24\" or string \"-23\" or string \"-22\" or string \"-21\" or string \"-20\" or string \"-19\" or string \"-18\" or string \"-17\" or string \"-16\" or string \"-15\" or string \"-14\" or string \"-13\" or string \"-12\" or string \"-11\" or string \"-10\" or string \"-9\" or string \"-8\" or string \"-7\" or string \"-6\" or string \"-5\" or string \"-4\" or string \"-3\" or string \"-2\" or string \"-1\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\", followed by ,, followed by string \"-31\" or string \"-30\" or string \"-29\" or string \"-28\" or string \"-27\" or string \"-26\" or string \"-25\" or string \"-24\" or string \"-23\" or string \"-22\" or string \"-21\" or string \"-20\" or string \"-19\" or string \"-18\" or string \"-17\" or string \"-16\" or string \"-15\" or string \"-14\" or string \"-13\" or string \"-12\" or string \"-11\" or string \"-10\" or string \"-9\" or string \"-8\" or string \"-7\" or string \"-6\" or string \"-5\" or string \"-4\" or string \"-3\" or string \"-2\" or string \"-1\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\"",
      rest, context, line, offset}
   end
 
@@ -366,7 +366,7 @@ defmodule CalendarRecurrence.RRULE.Parser do
 
   defp parse__5(rest, _acc, _stack, context, line, offset) do
     {:error,
-     "expected string \"FREQ\", followed by string \"=\", followed by string \"SECONDLY\" or string \"MINUTELY\" or string \"HOURLY\" or string \"DAILY\" or string \"WEEKLY\" or string \"MONTHLY\" or string \"YEARLY\" or string \"UNTIL\", followed by string \"=\", followed by datetime or date or string \"COUNT\", followed by string \"=\", followed by ASCII character in the range \"0\" to \"9\", followed by ASCII character in the range \"0\" to \"9\" or string \"INTERVAL\", followed by string \"=\", followed by ASCII character in the range \"0\" to \"9\", followed by ASCII character in the range \"0\" to \"9\" or string \"BYSECOND\", followed by string \"=\", followed by string \"59\" or string \"58\" or string \"57\" or string \"56\" or string \"55\" or string \"54\" or string \"53\" or string \"52\" or string \"51\" or string \"50\" or string \"49\" or string \"48\" or string \"47\" or string \"46\" or string \"45\" or string \"44\" or string \"43\" or string \"42\" or string \"41\" or string \"40\" or string \"39\" or string \"38\" or string \"37\" or string \"36\" or string \"35\" or string \"34\" or string \"33\" or string \"32\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\", followed by ,, followed by string \"59\" or string \"58\" or string \"57\" or string \"56\" or string \"55\" or string \"54\" or string \"53\" or string \"52\" or string \"51\" or string \"50\" or string \"49\" or string \"48\" or string \"47\" or string \"46\" or string \"45\" or string \"44\" or string \"43\" or string \"42\" or string \"41\" or string \"40\" or string \"39\" or string \"38\" or string \"37\" or string \"36\" or string \"35\" or string \"34\" or string \"33\" or string \"32\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\" or string \"BYMINUTE\", followed by string \"=\", followed by string \"59\" or string \"58\" or string \"57\" or string \"56\" or string \"55\" or string \"54\" or string \"53\" or string \"52\" or string \"51\" or string \"50\" or string \"49\" or string \"48\" or string \"47\" or string \"46\" or string \"45\" or string \"44\" or string \"43\" or string \"42\" or string \"41\" or string \"40\" or string \"39\" or string \"38\" or string \"37\" or string \"36\" or string \"35\" or string \"34\" or string \"33\" or string \"32\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\", followed by ,, followed by string \"59\" or string \"58\" or string \"57\" or string \"56\" or string \"55\" or string \"54\" or string \"53\" or string \"52\" or string \"51\" or string \"50\" or string \"49\" or string \"48\" or string \"47\" or string \"46\" or string \"45\" or string \"44\" or string \"43\" or string \"42\" or string \"41\" or string \"40\" or string \"39\" or string \"38\" or string \"37\" or string \"36\" or string \"35\" or string \"34\" or string \"33\" or string \"32\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\" or string \"BYHOUR\", followed by string \"=\", followed by string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\", followed by ,, followed by string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\" or string \"BYDAY\", followed by string \"=\", followed by string \"SU\" or string \"MO\" or string \"TU\" or string \"WE\" or string \"TH\" or string \"FR\" or string \"SA\", followed by ,, followed by string \"SU\" or string \"MO\" or string \"TU\" or string \"WE\" or string \"TH\" or string \"FR\" or string \"SA\" or string \"BYDAY\", followed by string \"=\", followed by string \"SU\" or string \"MO\" or string \"TU\" or string \"WE\" or string \"TH\" or string \"FR\" or string \"SA\", followed by ,, followed by string \"SU\" or string \"MO\" or string \"TU\" or string \"WE\" or string \"TH\" or string \"FR\" or string \"SA\" or string \"BYMONTH\", followed by string \"=\", followed by string \"1\" or string \"2\" or string \"3\" or string \"4\" or string \"5\" or string \"6\" or string \"7\" or string \"8\" or string \"9\" or string \"10\" or string \"11\" or string \"12\", followed by ,, followed by string \"1\" or string \"2\" or string \"3\" or string \"4\" or string \"5\" or string \"6\" or string \"7\" or string \"8\" or string \"9\" or string \"10\" or string \"11\" or string \"12\" or string \"BYMONTHDAY\", followed by string \"=\", followed by string \"-31\" or string \"-30\" or string \"-29\" or string \"-28\" or string \"-27\" or string \"-26\" or string \"-25\" or string \"-24\" or string \"-23\" or string \"-22\" or string \"-21\" or string \"-20\" or string \"-19\" or string \"-18\" or string \"-17\" or string \"-16\" or string \"-15\" or string \"-14\" or string \"-13\" or string \"-12\" or string \"-11\" or string \"-10\" or string \"-9\" or string \"-8\" or string \"-7\" or string \"-6\" or string \"-5\" or string \"-4\" or string \"-3\" or string \"-2\" or string \"-1\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\", followed by ,, followed by string \"-31\" or string \"-30\" or string \"-29\" or string \"-28\" or string \"-27\" or string \"-26\" or string \"-25\" or string \"-24\" or string \"-23\" or string \"-22\" or string \"-21\" or string \"-20\" or string \"-19\" or string \"-18\" or string \"-17\" or string \"-16\" or string \"-15\" or string \"-14\" or string \"-13\" or string \"-12\" or string \"-11\" or string \"-10\" or string \"-9\" or string \"-8\" or string \"-7\" or string \"-6\" or string \"-5\" or string \"-4\" or string \"-3\" or string \"-2\" or string \"-1\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\"",
+     "expected string \"FREQ\", followed by string \"=\", followed by string \"SECONDLY\" or string \"MINUTELY\" or string \"HOURLY\" or string \"DAILY\" or string \"WEEKLY\" or string \"MONTHLY\" or string \"YEARLY\" or string \"UNTIL\", followed by string \"=\", followed by datetime or date or string \"COUNT\", followed by string \"=\", followed by ASCII character in the range \"0\" to \"9\", followed by ASCII character in the range \"0\" to \"9\" or string \"INTERVAL\", followed by string \"=\", followed by ASCII character in the range \"0\" to \"9\", followed by ASCII character in the range \"0\" to \"9\" or string \"BYSECOND\", followed by string \"=\", followed by string \"59\" or string \"58\" or string \"57\" or string \"56\" or string \"55\" or string \"54\" or string \"53\" or string \"52\" or string \"51\" or string \"50\" or string \"49\" or string \"48\" or string \"47\" or string \"46\" or string \"45\" or string \"44\" or string \"43\" or string \"42\" or string \"41\" or string \"40\" or string \"39\" or string \"38\" or string \"37\" or string \"36\" or string \"35\" or string \"34\" or string \"33\" or string \"32\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\", followed by ,, followed by string \"59\" or string \"58\" or string \"57\" or string \"56\" or string \"55\" or string \"54\" or string \"53\" or string \"52\" or string \"51\" or string \"50\" or string \"49\" or string \"48\" or string \"47\" or string \"46\" or string \"45\" or string \"44\" or string \"43\" or string \"42\" or string \"41\" or string \"40\" or string \"39\" or string \"38\" or string \"37\" or string \"36\" or string \"35\" or string \"34\" or string \"33\" or string \"32\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\" or string \"BYMINUTE\", followed by string \"=\", followed by string \"59\" or string \"58\" or string \"57\" or string \"56\" or string \"55\" or string \"54\" or string \"53\" or string \"52\" or string \"51\" or string \"50\" or string \"49\" or string \"48\" or string \"47\" or string \"46\" or string \"45\" or string \"44\" or string \"43\" or string \"42\" or string \"41\" or string \"40\" or string \"39\" or string \"38\" or string \"37\" or string \"36\" or string \"35\" or string \"34\" or string \"33\" or string \"32\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\", followed by ,, followed by string \"59\" or string \"58\" or string \"57\" or string \"56\" or string \"55\" or string \"54\" or string \"53\" or string \"52\" or string \"51\" or string \"50\" or string \"49\" or string \"48\" or string \"47\" or string \"46\" or string \"45\" or string \"44\" or string \"43\" or string \"42\" or string \"41\" or string \"40\" or string \"39\" or string \"38\" or string \"37\" or string \"36\" or string \"35\" or string \"34\" or string \"33\" or string \"32\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\" or string \"BYHOUR\", followed by string \"=\", followed by string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\", followed by ,, followed by string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\" or string \"0\" or string \"BYDAY\", followed by string \"=\", followed by string \"-\" or string \"+\" or nothing, followed by ASCII character in the range \"0\" to \"9\", followed by ASCII character in the range \"0\" to \"9\", followed by string \"SU\" or string \"MO\" or string \"TU\" or string \"WE\" or string \"TH\" or string \"FR\" or string \"SA\" or string \"SU\" or string \"MO\" or string \"TU\" or string \"WE\" or string \"TH\" or string \"FR\" or string \"SA\", followed by ,, followed by string \"-\" or string \"+\" or nothing, followed by ASCII character in the range \"0\" to \"9\", followed by ASCII character in the range \"0\" to \"9\", followed by string \"SU\" or string \"MO\" or string \"TU\" or string \"WE\" or string \"TH\" or string \"FR\" or string \"SA\" or string \"SU\" or string \"MO\" or string \"TU\" or string \"WE\" or string \"TH\" or string \"FR\" or string \"SA\" or string \"BYMONTH\", followed by string \"=\", followed by string \"1\" or string \"2\" or string \"3\" or string \"4\" or string \"5\" or string \"6\" or string \"7\" or string \"8\" or string \"9\" or string \"10\" or string \"11\" or string \"12\", followed by ,, followed by string \"1\" or string \"2\" or string \"3\" or string \"4\" or string \"5\" or string \"6\" or string \"7\" or string \"8\" or string \"9\" or string \"10\" or string \"11\" or string \"12\" or string \"BYMONTHDAY\", followed by string \"=\", followed by string \"-31\" or string \"-30\" or string \"-29\" or string \"-28\" or string \"-27\" or string \"-26\" or string \"-25\" or string \"-24\" or string \"-23\" or string \"-22\" or string \"-21\" or string \"-20\" or string \"-19\" or string \"-18\" or string \"-17\" or string \"-16\" or string \"-15\" or string \"-14\" or string \"-13\" or string \"-12\" or string \"-11\" or string \"-10\" or string \"-9\" or string \"-8\" or string \"-7\" or string \"-6\" or string \"-5\" or string \"-4\" or string \"-3\" or string \"-2\" or string \"-1\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\", followed by ,, followed by string \"-31\" or string \"-30\" or string \"-29\" or string \"-28\" or string \"-27\" or string \"-26\" or string \"-25\" or string \"-24\" or string \"-23\" or string \"-22\" or string \"-21\" or string \"-20\" or string \"-19\" or string \"-18\" or string \"-17\" or string \"-16\" or string \"-15\" or string \"-14\" or string \"-13\" or string \"-12\" or string \"-11\" or string \"-10\" or string \"-9\" or string \"-8\" or string \"-7\" or string \"-6\" or string \"-5\" or string \"-4\" or string \"-3\" or string \"-2\" or string \"-1\" or string \"31\" or string \"30\" or string \"29\" or string \"28\" or string \"27\" or string \"26\" or string \"25\" or string \"24\" or string \"23\" or string \"22\" or string \"21\" or string \"20\" or string \"19\" or string \"18\" or string \"17\" or string \"16\" or string \"15\" or string \"14\" or string \"13\" or string \"12\" or string \"11\" or string \"10\" or string \"9\" or string \"8\" or string \"7\" or string \"6\" or string \"5\" or string \"4\" or string \"3\" or string \"2\" or string \"1\"",
      rest, context, line, offset}
   end
 
@@ -849,1647 +849,115 @@ defmodule CalendarRecurrence.RRULE.Parser do
     parse__27(rest, [], [acc | stack], context, line, offset)
   end
 
-  defp parse__27(<<"SU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__28(rest, ["SU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__27(rest, acc, stack, context, line, offset) do
+    parse__32(rest, [], [{rest, context, line, offset}, acc | stack], context, line, offset)
   end
 
-  defp parse__27(<<"MO", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__28(rest, ["MO"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__29(<<"SU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__30(rest, ["SU"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__27(<<"TU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__28(rest, ["TU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__29(<<"MO", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__30(rest, ["MO"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__27(<<"WE", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__28(rest, ["WE"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__29(<<"TU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__30(rest, ["TU"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__27(<<"TH", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__28(rest, ["TH"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__29(<<"WE", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__30(rest, ["WE"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__27(<<"FR", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__28(rest, ["FR"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__29(<<"TH", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__30(rest, ["TH"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__27(<<"SA", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__28(rest, ["SA"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__29(<<"FR", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__30(rest, ["FR"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__27(rest, _acc, stack, context, line, offset) do
-    [acc | stack] = stack
+  defp parse__29(<<"SA", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__30(rest, ["SA"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__29(rest, _acc, stack, context, line, offset) do
+    [_, _, acc | stack] = stack
     parse__24(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__28(rest, acc, stack, context, line, offset) do
-    parse__30(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
+  defp parse__30(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__28(rest, acc ++ previous_acc, stack, context, line, offset)
   end
 
-  defp parse__30(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__31(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__31(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__29(rest, [], stack, context, line, offset)
   end
 
-  defp parse__30(rest, acc, stack, context, line, offset) do
-    parse__29(rest, acc, stack, context, line, offset)
+  defp parse__32(rest, acc, stack, context, line, offset) do
+    parse__33(rest, [], [acc | stack], context, line, offset)
   end
 
-  defp parse__31(<<"SU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__32(rest, ["SU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__33(<<"-", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__34(rest, ["-"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__31(<<"MO", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__32(rest, ["MO"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__33(<<"+", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__34(rest, ["+"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__31(<<"TU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__32(rest, ["TU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__33(<<rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__34(rest, ["+"] ++ acc, stack, context, comb__line, comb__offset)
   end
 
-  defp parse__31(<<"WE", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__32(rest, ["WE"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__33(rest, _acc, stack, context, line, offset) do
+    [acc | stack] = stack
+    parse__31(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__31(<<"TH", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__32(rest, ["TH"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__34(rest, acc, stack, context, line, offset) do
+    parse__35(rest, [], [acc | stack], context, line, offset)
   end
 
-  defp parse__31(<<"FR", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__32(rest, ["FR"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__35(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 do
+    parse__36(rest, [x0 - 48] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__31(<<"SA", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__32(rest, ["SA"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__31(rest, acc, stack, context, line, offset) do
-    parse__29(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__29(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
-    parse__33(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__32(
-         inner_rest,
-         inner_acc,
-         [{rest, acc, context, line, offset} | stack],
-         inner_context,
-         inner_line,
-         inner_offset
-       ) do
-    _ = {rest, acc, context, line, offset}
-
-    parse__30(
-      inner_rest,
-      [],
-      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
-      inner_context,
-      inner_line,
-      inner_offset
-    )
-  end
-
-  defp parse__33(rest, user_acc, [acc | stack], context, line, offset) do
-    _ = user_acc
-    parse__34(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
-  end
-
-  defp parse__34(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__2(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__35(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__25(rest, [], stack, context, line, offset)
-  end
-
-  defp parse__36(<<"BYDAY", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__37(rest, ["BYDAY"] ++ acc, stack, context, comb__line, comb__offset + 6)
+  defp parse__35(rest, _acc, stack, context, line, offset) do
+    [_, acc | stack] = stack
+    parse__31(rest, acc, stack, context, line, offset)
   end
 
   defp parse__36(rest, acc, stack, context, line, offset) do
-    parse__35(rest, acc, stack, context, line, offset)
+    parse__38(rest, acc, [1 | stack], context, line, offset)
   end
 
-  defp parse__37(rest, acc, stack, context, line, offset) do
-    parse__38(rest, [], [acc | stack], context, line, offset)
+  defp parse__38(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 do
+    parse__39(rest, [x0] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__38(<<"SU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__39(rest, ["SU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__38(rest, acc, stack, context, line, offset) do
+    parse__37(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__38(<<"MO", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__39(rest, ["MO"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__38(<<"TU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__39(rest, ["TU"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__38(<<"WE", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__39(rest, ["WE"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__38(<<"TH", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__39(rest, ["TH"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__38(<<"FR", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__39(rest, ["FR"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__38(<<"SA", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__39(rest, ["SA"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__38(rest, _acc, stack, context, line, offset) do
-    [acc | stack] = stack
-    parse__35(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__39(rest, acc, stack, context, line, offset) do
-    parse__41(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
-  end
-
-  defp parse__41(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__42(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__41(rest, acc, stack, context, line, offset) do
+  defp parse__37(rest, acc, [_ | stack], context, line, offset) do
     parse__40(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__42(<<"SU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__43(rest, ["SU"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__42(<<"MO", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__43(rest, ["MO"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__42(<<"TU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__43(rest, ["TU"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__42(<<"WE", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__43(rest, ["WE"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__42(<<"TH", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__43(rest, ["TH"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__42(<<"FR", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__43(rest, ["FR"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__42(<<"SA", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__43(rest, ["SA"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__42(rest, acc, stack, context, line, offset) do
+  defp parse__39(rest, acc, [1 | stack], context, line, offset) do
     parse__40(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__40(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
-    parse__44(rest, acc, stack, context, line, offset)
+  defp parse__39(rest, acc, [count | stack], context, line, offset) do
+    parse__38(rest, acc, [count - 1 | stack], context, line, offset)
   end
 
-  defp parse__43(
-         inner_rest,
-         inner_acc,
-         [{rest, acc, context, line, offset} | stack],
-         inner_context,
-         inner_line,
-         inner_offset
-       ) do
-    _ = {rest, acc, context, line, offset}
+  defp parse__40(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
 
     parse__41(
-      inner_rest,
-      [],
-      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
-      inner_context,
-      inner_line,
-      inner_offset
-    )
-  end
-
-  defp parse__44(rest, user_acc, [acc | stack], context, line, offset) do
-    _ = user_acc
-    parse__45(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
-  end
-
-  defp parse__45(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__2(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__46(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__36(rest, [], stack, context, line, offset)
-  end
-
-  defp parse__47(<<"BYHOUR", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__48(rest, ["BYHOUR"] ++ acc, stack, context, comb__line, comb__offset + 7)
-  end
-
-  defp parse__47(rest, acc, stack, context, line, offset) do
-    parse__46(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__48(rest, acc, stack, context, line, offset) do
-    parse__49(rest, [], [acc | stack], context, line, offset)
-  end
-
-  defp parse__49(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__49(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__49(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__49(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__49(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__49(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__49(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__49(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__49(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__49(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__49(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__49(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__49(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__49(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__49(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__49(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__49(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__49(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__49(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__49(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__49(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__49(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__49(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__49(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__50(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__49(rest, _acc, stack, context, line, offset) do
-    [acc | stack] = stack
-    parse__46(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__50(rest, acc, stack, context, line, offset) do
-    parse__52(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
-  end
-
-  defp parse__52(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__53(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__52(rest, acc, stack, context, line, offset) do
-    parse__51(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__53(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__53(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__53(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__53(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__53(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__53(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__53(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__53(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__53(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__53(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__53(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__53(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__53(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__53(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__53(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__53(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__53(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__53(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__53(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__53(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__53(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__53(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__53(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__53(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__54(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__53(rest, acc, stack, context, line, offset) do
-    parse__51(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__51(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
-    parse__55(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__54(
-         inner_rest,
-         inner_acc,
-         [{rest, acc, context, line, offset} | stack],
-         inner_context,
-         inner_line,
-         inner_offset
-       ) do
-    _ = {rest, acc, context, line, offset}
-
-    parse__52(
-      inner_rest,
-      [],
-      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
-      inner_context,
-      inner_line,
-      inner_offset
-    )
-  end
-
-  defp parse__55(rest, user_acc, [acc | stack], context, line, offset) do
-    _ = user_acc
-    parse__56(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
-  end
-
-  defp parse__56(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__2(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__57(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__47(rest, [], stack, context, line, offset)
-  end
-
-  defp parse__58(<<"BYMINUTE", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__59(rest, ["BYMINUTE"] ++ acc, stack, context, comb__line, comb__offset + 9)
-  end
-
-  defp parse__58(rest, acc, stack, context, line, offset) do
-    parse__57(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__59(rest, acc, stack, context, line, offset) do
-    parse__60(rest, [], [acc | stack], context, line, offset)
-  end
-
-  defp parse__60(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__60(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__60(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__60(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__60(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__60(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__60(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__60(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__60(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__60(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__60(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__61(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__60(rest, _acc, stack, context, line, offset) do
-    [acc | stack] = stack
-    parse__57(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__61(rest, acc, stack, context, line, offset) do
-    parse__63(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
-  end
-
-  defp parse__63(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__64(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__63(rest, acc, stack, context, line, offset) do
-    parse__62(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__64(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__64(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__64(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__64(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__64(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__64(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__64(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__64(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__64(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__64(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__64(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__65(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__64(rest, acc, stack, context, line, offset) do
-    parse__62(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__62(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
-    parse__66(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__65(
-         inner_rest,
-         inner_acc,
-         [{rest, acc, context, line, offset} | stack],
-         inner_context,
-         inner_line,
-         inner_offset
-       ) do
-    _ = {rest, acc, context, line, offset}
-
-    parse__63(
-      inner_rest,
-      [],
-      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
-      inner_context,
-      inner_line,
-      inner_offset
-    )
-  end
-
-  defp parse__66(rest, user_acc, [acc | stack], context, line, offset) do
-    _ = user_acc
-    parse__67(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
-  end
-
-  defp parse__67(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__2(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__68(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__58(rest, [], stack, context, line, offset)
-  end
-
-  defp parse__69(<<"BYSECOND", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__70(rest, ["BYSECOND"] ++ acc, stack, context, comb__line, comb__offset + 9)
-  end
-
-  defp parse__69(rest, acc, stack, context, line, offset) do
-    parse__68(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__70(rest, acc, stack, context, line, offset) do
-    parse__71(rest, [], [acc | stack], context, line, offset)
-  end
-
-  defp parse__71(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__71(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__71(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__71(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__71(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__71(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__71(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__71(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__71(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__71(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__71(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__72(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__71(rest, _acc, stack, context, line, offset) do
-    [acc | stack] = stack
-    parse__68(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__72(rest, acc, stack, context, line, offset) do
-    parse__74(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
-  end
-
-  defp parse__74(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__75(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__74(rest, acc, stack, context, line, offset) do
-    parse__73(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__75(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__75(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__75(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__75(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__75(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__75(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__75(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__75(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__75(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__75(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__75(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__76(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__75(rest, acc, stack, context, line, offset) do
-    parse__73(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__73(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
-    parse__77(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__76(
-         inner_rest,
-         inner_acc,
-         [{rest, acc, context, line, offset} | stack],
-         inner_context,
-         inner_line,
-         inner_offset
-       ) do
-    _ = {rest, acc, context, line, offset}
-
-    parse__74(
-      inner_rest,
-      [],
-      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
-      inner_context,
-      inner_line,
-      inner_offset
-    )
-  end
-
-  defp parse__77(rest, user_acc, [acc | stack], context, line, offset) do
-    _ = user_acc
-    parse__78(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
-  end
-
-  defp parse__78(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__2(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__79(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__69(rest, [], stack, context, line, offset)
-  end
-
-  defp parse__80(<<"INTERVAL", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__81(rest, ["INTERVAL"] ++ acc, stack, context, comb__line, comb__offset + 9)
-  end
-
-  defp parse__80(rest, acc, stack, context, line, offset) do
-    parse__79(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__81(rest, acc, stack, context, line, offset) do
-    parse__82(rest, [], [acc | stack], context, line, offset)
-  end
-
-  defp parse__82(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
-       when x0 >= 48 and x0 <= 57 do
-    parse__83(rest, [x0 - 48] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__82(rest, _acc, stack, context, line, offset) do
-    [acc | stack] = stack
-    parse__79(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__83(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
-       when x0 >= 48 and x0 <= 57 do
-    parse__85(rest, [x0] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__83(rest, acc, stack, context, line, offset) do
-    parse__84(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__85(rest, acc, stack, context, line, offset) do
-    parse__83(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__84(rest, user_acc, [acc | stack], context, line, offset) do
-    _ = user_acc
-
-    parse__86(
       rest,
       (
         [head | tail] = :lists.reverse(user_acc)
@@ -2502,16 +970,1074 @@ defmodule CalendarRecurrence.RRULE.Parser do
     )
   end
 
+  defp parse__41(<<"SU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__42(rest, ["SU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__41(<<"MO", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__42(rest, ["MO"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__41(<<"TU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__42(rest, ["TU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__41(<<"WE", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__42(rest, ["WE"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__41(<<"TH", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__42(rest, ["TH"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__41(<<"FR", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__42(rest, ["FR"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__41(<<"SA", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__42(rest, ["SA"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__41(rest, _acc, stack, context, line, offset) do
+    [acc | stack] = stack
+    parse__31(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__42(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+    parse__43(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
+  end
+
+  defp parse__43(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__28(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__28(rest, acc, stack, context, line, offset) do
+    parse__45(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
+  end
+
+  defp parse__45(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__46(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__45(rest, acc, stack, context, line, offset) do
+    parse__44(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__46(rest, acc, stack, context, line, offset) do
+    parse__51(rest, [], [{rest, context, line, offset}, acc | stack], context, line, offset)
+  end
+
+  defp parse__48(<<"SU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__49(rest, ["SU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__48(<<"MO", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__49(rest, ["MO"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__48(<<"TU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__49(rest, ["TU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__48(<<"WE", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__49(rest, ["WE"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__48(<<"TH", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__49(rest, ["TH"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__48(<<"FR", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__49(rest, ["FR"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__48(<<"SA", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__49(rest, ["SA"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__48(rest, _acc, stack, context, line, offset) do
+    [_, acc | stack] = stack
+    parse__44(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__49(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__47(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__50(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__48(rest, [], stack, context, line, offset)
+  end
+
+  defp parse__51(rest, acc, stack, context, line, offset) do
+    parse__52(rest, [], [acc | stack], context, line, offset)
+  end
+
+  defp parse__52(<<"-", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__53(rest, ["-"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__52(<<"+", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__53(rest, ["+"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__52(<<rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__53(rest, ["+"] ++ acc, stack, context, comb__line, comb__offset)
+  end
+
+  defp parse__52(rest, _acc, stack, context, line, offset) do
+    [acc | stack] = stack
+    parse__50(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__53(rest, acc, stack, context, line, offset) do
+    parse__54(rest, [], [acc | stack], context, line, offset)
+  end
+
+  defp parse__54(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 do
+    parse__55(rest, [x0 - 48] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__54(rest, _acc, stack, context, line, offset) do
+    [_, acc | stack] = stack
+    parse__50(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__55(rest, acc, stack, context, line, offset) do
+    parse__57(rest, acc, [1 | stack], context, line, offset)
+  end
+
+  defp parse__57(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 do
+    parse__58(rest, [x0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__57(rest, acc, stack, context, line, offset) do
+    parse__56(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__56(rest, acc, [_ | stack], context, line, offset) do
+    parse__59(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__58(rest, acc, [1 | stack], context, line, offset) do
+    parse__59(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__58(rest, acc, [count | stack], context, line, offset) do
+    parse__57(rest, acc, [count - 1 | stack], context, line, offset)
+  end
+
+  defp parse__59(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+
+    parse__60(
+      rest,
+      (
+        [head | tail] = :lists.reverse(user_acc)
+        [:lists.foldl(fn x, acc -> x - 48 + acc * 10 end, head, tail)]
+      ) ++ acc,
+      stack,
+      context,
+      line,
+      offset
+    )
+  end
+
+  defp parse__60(<<"SU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__61(rest, ["SU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__60(<<"MO", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__61(rest, ["MO"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__60(<<"TU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__61(rest, ["TU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__60(<<"WE", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__61(rest, ["WE"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__60(<<"TH", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__61(rest, ["TH"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__60(<<"FR", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__61(rest, ["FR"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__60(<<"SA", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__61(rest, ["SA"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__60(rest, _acc, stack, context, line, offset) do
+    [acc | stack] = stack
+    parse__50(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__61(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+    parse__62(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
+  end
+
+  defp parse__62(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__47(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__44(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
+    parse__63(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__47(
+         inner_rest,
+         inner_acc,
+         [{rest, acc, context, line, offset} | stack],
+         inner_context,
+         inner_line,
+         inner_offset
+       ) do
+    _ = {rest, acc, context, line, offset}
+
+    parse__45(
+      inner_rest,
+      [],
+      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
+      inner_context,
+      inner_line,
+      inner_offset
+    )
+  end
+
+  defp parse__63(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+    parse__64(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
+  end
+
+  defp parse__64(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__2(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__65(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__25(rest, [], stack, context, line, offset)
+  end
+
+  defp parse__66(<<"BYHOUR", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__67(rest, ["BYHOUR"] ++ acc, stack, context, comb__line, comb__offset + 7)
+  end
+
+  defp parse__66(rest, acc, stack, context, line, offset) do
+    parse__65(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__67(rest, acc, stack, context, line, offset) do
+    parse__68(rest, [], [acc | stack], context, line, offset)
+  end
+
+  defp parse__68(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__68(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__68(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__68(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__68(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__68(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__68(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__68(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__68(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__68(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__68(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__68(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__68(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__68(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__68(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__68(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__68(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__68(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__68(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__68(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__68(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__68(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__68(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__68(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__69(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__68(rest, _acc, stack, context, line, offset) do
+    [acc | stack] = stack
+    parse__65(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__69(rest, acc, stack, context, line, offset) do
+    parse__71(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
+  end
+
+  defp parse__71(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__72(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__71(rest, acc, stack, context, line, offset) do
+    parse__70(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__72(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__72(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__72(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__72(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__72(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__72(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__72(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__72(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__72(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__72(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__72(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__72(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__72(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__72(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__72(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__72(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__72(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__72(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__72(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__72(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__72(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__72(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__72(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__72(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__73(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__72(rest, acc, stack, context, line, offset) do
+    parse__70(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__70(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
+    parse__74(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__73(
+         inner_rest,
+         inner_acc,
+         [{rest, acc, context, line, offset} | stack],
+         inner_context,
+         inner_line,
+         inner_offset
+       ) do
+    _ = {rest, acc, context, line, offset}
+
+    parse__71(
+      inner_rest,
+      [],
+      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
+      inner_context,
+      inner_line,
+      inner_offset
+    )
+  end
+
+  defp parse__74(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+    parse__75(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
+  end
+
+  defp parse__75(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__2(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__76(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__66(rest, [], stack, context, line, offset)
+  end
+
+  defp parse__77(<<"BYMINUTE", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__78(rest, ["BYMINUTE"] ++ acc, stack, context, comb__line, comb__offset + 9)
+  end
+
+  defp parse__77(rest, acc, stack, context, line, offset) do
+    parse__76(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__78(rest, acc, stack, context, line, offset) do
+    parse__79(rest, [], [acc | stack], context, line, offset)
+  end
+
+  defp parse__79(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__79(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__79(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__79(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__79(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__79(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__79(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__79(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__79(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__79(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__79(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__80(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__79(rest, _acc, stack, context, line, offset) do
+    [acc | stack] = stack
+    parse__76(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__80(rest, acc, stack, context, line, offset) do
+    parse__82(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
+  end
+
+  defp parse__82(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__83(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__82(rest, acc, stack, context, line, offset) do
+    parse__81(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__83(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__83(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__83(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__83(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__83(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__83(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__83(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__83(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__83(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__83(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__83(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__84(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__83(rest, acc, stack, context, line, offset) do
+    parse__81(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__81(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
+    parse__85(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__84(
+         inner_rest,
+         inner_acc,
+         [{rest, acc, context, line, offset} | stack],
+         inner_context,
+         inner_line,
+         inner_offset
+       ) do
+    _ = {rest, acc, context, line, offset}
+
+    parse__82(
+      inner_rest,
+      [],
+      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
+      inner_context,
+      inner_line,
+      inner_offset
+    )
+  end
+
+  defp parse__85(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+    parse__86(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
+  end
+
   defp parse__86(rest, acc, [_, previous_acc | stack], context, line, offset) do
     parse__2(rest, acc ++ previous_acc, stack, context, line, offset)
   end
 
   defp parse__87(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__80(rest, [], stack, context, line, offset)
+    parse__77(rest, [], stack, context, line, offset)
   end
 
-  defp parse__88(<<"COUNT", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__89(rest, ["COUNT"] ++ acc, stack, context, comb__line, comb__offset + 6)
+  defp parse__88(<<"BYSECOND", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__89(rest, ["BYSECOND"] ++ acc, stack, context, comb__line, comb__offset + 9)
   end
 
   defp parse__88(rest, acc, stack, context, line, offset) do
@@ -2522,9 +2048,244 @@ defmodule CalendarRecurrence.RRULE.Parser do
     parse__90(rest, [], [acc | stack], context, line, offset)
   end
 
-  defp parse__90(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
-       when x0 >= 48 and x0 <= 57 do
-    parse__91(rest, [x0 - 48] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__90(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__90(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__90(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__90(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__90(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__90(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__90(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__90(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__90(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__90(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__90(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__91(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
   defp parse__90(rest, _acc, stack, context, line, offset) do
@@ -2532,23 +2293,338 @@ defmodule CalendarRecurrence.RRULE.Parser do
     parse__87(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__91(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
-       when x0 >= 48 and x0 <= 57 do
-    parse__93(rest, [x0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__91(rest, acc, stack, context, line, offset) do
+    parse__93(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
   end
 
-  defp parse__91(rest, acc, stack, context, line, offset) do
-    parse__92(rest, acc, stack, context, line, offset)
+  defp parse__93(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__94(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
   defp parse__93(rest, acc, stack, context, line, offset) do
-    parse__91(rest, acc, stack, context, line, offset)
+    parse__92(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__92(rest, user_acc, [acc | stack], context, line, offset) do
+  defp parse__94(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__94(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__94(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__94(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__94(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__94(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__94(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__94(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__94(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__94(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__94(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__95(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__94(rest, acc, stack, context, line, offset) do
+    parse__92(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__92(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
+    parse__96(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__95(
+         inner_rest,
+         inner_acc,
+         [{rest, acc, context, line, offset} | stack],
+         inner_context,
+         inner_line,
+         inner_offset
+       ) do
+    _ = {rest, acc, context, line, offset}
+
+    parse__93(
+      inner_rest,
+      [],
+      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
+      inner_context,
+      inner_line,
+      inner_offset
+    )
+  end
+
+  defp parse__96(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+    parse__97(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
+  end
+
+  defp parse__97(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__2(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__98(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__88(rest, [], stack, context, line, offset)
+  end
+
+  defp parse__99(<<"INTERVAL", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__100(rest, ["INTERVAL"] ++ acc, stack, context, comb__line, comb__offset + 9)
+  end
+
+  defp parse__99(rest, acc, stack, context, line, offset) do
+    parse__98(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__100(rest, acc, stack, context, line, offset) do
+    parse__101(rest, [], [acc | stack], context, line, offset)
+  end
+
+  defp parse__101(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 do
+    parse__102(rest, [x0 - 48] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__101(rest, _acc, stack, context, line, offset) do
+    [acc | stack] = stack
+    parse__98(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__102(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 do
+    parse__104(rest, [x0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__102(rest, acc, stack, context, line, offset) do
+    parse__103(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__104(rest, acc, stack, context, line, offset) do
+    parse__102(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__103(rest, user_acc, [acc | stack], context, line, offset) do
     _ = user_acc
 
-    parse__94(
+    parse__105(
       rest,
       (
         [head | tail] = :lists.reverse(user_acc)
@@ -2561,1117 +2637,1176 @@ defmodule CalendarRecurrence.RRULE.Parser do
     )
   end
 
-  defp parse__94(rest, acc, [_, previous_acc | stack], context, line, offset) do
+  defp parse__105(rest, acc, [_, previous_acc | stack], context, line, offset) do
     parse__2(rest, acc ++ previous_acc, stack, context, line, offset)
   end
 
-  defp parse__95(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__88(rest, [], stack, context, line, offset)
+  defp parse__106(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__99(rest, [], stack, context, line, offset)
   end
 
-  defp parse__96(<<"UNTIL", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__97(rest, ["UNTIL"] ++ acc, stack, context, comb__line, comb__offset + 6)
-  end
-
-  defp parse__96(rest, acc, stack, context, line, offset) do
-    parse__95(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__97(rest, acc, stack, context, line, offset) do
-    parse__98(rest, [], [acc | stack], context, line, offset)
-  end
-
-  defp parse__98(rest, acc, stack, context, line, offset) do
-    parse__105(rest, [], [{rest, context, line, offset}, acc | stack], context, line, offset)
-  end
-
-  defp parse__100(<<x0, x1, x2, x3, rest::binary>>, acc, stack, context, comb__line, comb__offset)
-       when x0 >= 48 and x0 <= 57 and (x1 >= 48 and x1 <= 57) and (x2 >= 48 and x2 <= 57) and
-              (x3 >= 48 and x3 <= 57) do
-    parse__101(
-      rest,
-      [x3 - 48 + (x2 - 48) * 10 + (x1 - 48) * 100 + (x0 - 48) * 1000] ++ acc,
-      stack,
-      context,
-      comb__line,
-      comb__offset + 4
-    )
-  end
-
-  defp parse__100(rest, _acc, stack, context, line, offset) do
-    [_, _, acc | stack] = stack
-    parse__95(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__101(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__102(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__101(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__102(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__101(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__102(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__101(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__102(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__101(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__102(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__101(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__102(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__101(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__102(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__101(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__102(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__101(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__102(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__101(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__102(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__101(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__102(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__101(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__102(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__101(rest, _acc, stack, context, line, offset) do
-    [_, _, acc | stack] = stack
-    parse__95(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__102(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__103(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__102(rest, _acc, stack, context, line, offset) do
-    [_, _, acc | stack] = stack
-    parse__95(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__103(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__99(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__104(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__100(rest, [], stack, context, line, offset)
-  end
-
-  defp parse__105(<<x0, x1, x2, x3, rest::binary>>, acc, stack, context, comb__line, comb__offset)
-       when x0 >= 48 and x0 <= 57 and (x1 >= 48 and x1 <= 57) and (x2 >= 48 and x2 <= 57) and
-              (x3 >= 48 and x3 <= 57) do
-    parse__106(
-      rest,
-      [x3 - 48 + (x2 - 48) * 10 + (x1 - 48) * 100 + (x0 - 48) * 1000] ++ acc,
-      stack,
-      context,
-      comb__line,
-      comb__offset + 4
-    )
-  end
-
-  defp parse__105(rest, acc, stack, context, line, offset) do
-    parse__104(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__106(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__107(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__106(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__107(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__106(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__107(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__106(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__107(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__106(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__107(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__106(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__107(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__106(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__107(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__106(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__107(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__106(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__107(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__106(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__107(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__106(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__107(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__106(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__107(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__106(rest, acc, stack, context, line, offset) do
-    parse__104(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__107(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__107(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__108(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__107(<<"COUNT", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__108(rest, ["COUNT"] ++ acc, stack, context, comb__line, comb__offset + 6)
   end
 
   defp parse__107(rest, acc, stack, context, line, offset) do
-    parse__104(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__108(<<"T", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__109(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
+    parse__106(rest, acc, stack, context, line, offset)
   end
 
   defp parse__108(rest, acc, stack, context, line, offset) do
-    parse__104(rest, acc, stack, context, line, offset)
+    parse__109(rest, [], [acc | stack], context, line, offset)
   end
 
-  defp parse__109(<<"00", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__109(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 do
+    parse__110(rest, [x0 - 48] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__109(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__109(rest, _acc, stack, context, line, offset) do
+    [acc | stack] = stack
+    parse__106(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__109(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__110(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__109(rest, acc, stack, context, line, offset) do
-    parse__104(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__110(<<"00", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__110(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__111(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__110(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 do
+    parse__112(rest, [x0] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
   defp parse__110(rest, acc, stack, context, line, offset) do
-    parse__104(rest, acc, stack, context, line, offset)
+    parse__111(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__111(<<"00", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__112(rest, acc, stack, context, line, offset) do
+    parse__110(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__111(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
+  defp parse__111(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
 
-  defp parse__111(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__112(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__111(rest, acc, stack, context, line, offset) do
-    parse__104(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__112(<<"Z", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__113(rest, ["Z"] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__112(<<rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__113(rest, [] ++ acc, stack, context, comb__line, comb__offset)
+    parse__113(
+      rest,
+      (
+        [head | tail] = :lists.reverse(user_acc)
+        [:lists.foldl(fn x, acc -> x - 48 + acc * 10 end, head, tail)]
+      ) ++ acc,
+      stack,
+      context,
+      line,
+      offset
+    )
   end
 
   defp parse__113(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__99(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__99(rest, user_acc, [acc | stack], context, line, offset) do
-    _ = user_acc
-    parse__114(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
-  end
-
-  defp parse__114(rest, acc, [_, previous_acc | stack], context, line, offset) do
     parse__2(rest, acc ++ previous_acc, stack, context, line, offset)
   end
 
-  defp parse__115(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__96(rest, [], stack, context, line, offset)
+  defp parse__114(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__107(rest, [], stack, context, line, offset)
   end
 
-  defp parse__116(<<"FREQ", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__117(rest, ["FREQ"] ++ acc, stack, context, comb__line, comb__offset + 5)
+  defp parse__115(<<"UNTIL", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__116(rest, ["UNTIL"] ++ acc, stack, context, comb__line, comb__offset + 6)
+  end
+
+  defp parse__115(rest, acc, stack, context, line, offset) do
+    parse__114(rest, acc, stack, context, line, offset)
   end
 
   defp parse__116(rest, acc, stack, context, line, offset) do
-    parse__115(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__117(<<"SECONDLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__118(rest, ["SECONDLY"] ++ acc, stack, context, comb__line, comb__offset + 8)
-  end
-
-  defp parse__117(<<"MINUTELY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__118(rest, ["MINUTELY"] ++ acc, stack, context, comb__line, comb__offset + 8)
-  end
-
-  defp parse__117(<<"HOURLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__118(rest, ["HOURLY"] ++ acc, stack, context, comb__line, comb__offset + 6)
-  end
-
-  defp parse__117(<<"DAILY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__118(rest, ["DAILY"] ++ acc, stack, context, comb__line, comb__offset + 5)
-  end
-
-  defp parse__117(<<"WEEKLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__118(rest, ["WEEKLY"] ++ acc, stack, context, comb__line, comb__offset + 6)
-  end
-
-  defp parse__117(<<"MONTHLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__118(rest, ["MONTHLY"] ++ acc, stack, context, comb__line, comb__offset + 7)
-  end
-
-  defp parse__117(<<"YEARLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__118(rest, ["YEARLY"] ++ acc, stack, context, comb__line, comb__offset + 6)
+    parse__117(rest, [], [acc | stack], context, line, offset)
   end
 
   defp parse__117(rest, acc, stack, context, line, offset) do
-    parse__115(rest, acc, stack, context, line, offset)
+    parse__124(rest, [], [{rest, context, line, offset}, acc | stack], context, line, offset)
   end
 
-  defp parse__118(rest, acc, [_, previous_acc | stack], context, line, offset) do
+  defp parse__119(<<x0, x1, x2, x3, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 and (x1 >= 48 and x1 <= 57) and (x2 >= 48 and x2 <= 57) and
+              (x3 >= 48 and x3 <= 57) do
+    parse__120(
+      rest,
+      [x3 - 48 + (x2 - 48) * 10 + (x1 - 48) * 100 + (x0 - 48) * 1000] ++ acc,
+      stack,
+      context,
+      comb__line,
+      comb__offset + 4
+    )
+  end
+
+  defp parse__119(rest, _acc, stack, context, line, offset) do
+    [_, _, acc | stack] = stack
+    parse__114(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__120(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__121(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__120(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__121(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__120(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__121(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__120(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__121(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__120(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__121(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__120(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__121(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__120(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__121(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__120(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__121(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__120(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__121(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__120(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__121(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__120(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__121(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__120(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__121(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__120(rest, _acc, stack, context, line, offset) do
+    [_, _, acc | stack] = stack
+    parse__114(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__121(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__122(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__121(rest, _acc, stack, context, line, offset) do
+    [_, _, acc | stack] = stack
+    parse__114(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__122(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__118(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__123(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__119(rest, [], stack, context, line, offset)
+  end
+
+  defp parse__124(<<x0, x1, x2, x3, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 and (x1 >= 48 and x1 <= 57) and (x2 >= 48 and x2 <= 57) and
+              (x3 >= 48 and x3 <= 57) do
+    parse__125(
+      rest,
+      [x3 - 48 + (x2 - 48) * 10 + (x1 - 48) * 100 + (x0 - 48) * 1000] ++ acc,
+      stack,
+      context,
+      comb__line,
+      comb__offset + 4
+    )
+  end
+
+  defp parse__124(rest, acc, stack, context, line, offset) do
+    parse__123(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__125(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__126(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__125(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__126(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__125(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__126(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__125(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__126(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__125(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__126(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__125(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__126(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__125(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__126(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__125(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__126(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__125(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__126(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__125(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__126(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__125(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__126(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__125(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__126(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__125(rest, acc, stack, context, line, offset) do
+    parse__123(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__126(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__127(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__126(rest, acc, stack, context, line, offset) do
+    parse__123(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__127(<<"T", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__128(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__127(rest, acc, stack, context, line, offset) do
+    parse__123(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__128(<<"00", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__129(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__128(rest, acc, stack, context, line, offset) do
+    parse__123(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__129(<<"00", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__130(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__129(rest, acc, stack, context, line, offset) do
+    parse__123(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__130(<<"00", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__131(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__130(rest, acc, stack, context, line, offset) do
+    parse__123(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__131(<<"Z", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__132(rest, ["Z"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__131(<<rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__132(rest, [] ++ acc, stack, context, comb__line, comb__offset)
+  end
+
+  defp parse__132(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__118(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__118(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+    parse__133(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
+  end
+
+  defp parse__133(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__2(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__134(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__115(rest, [], stack, context, line, offset)
+  end
+
+  defp parse__135(<<"FREQ", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__136(rest, ["FREQ"] ++ acc, stack, context, comb__line, comb__offset + 5)
+  end
+
+  defp parse__135(rest, acc, stack, context, line, offset) do
+    parse__134(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__136(<<"SECONDLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__137(rest, ["SECONDLY"] ++ acc, stack, context, comb__line, comb__offset + 8)
+  end
+
+  defp parse__136(<<"MINUTELY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__137(rest, ["MINUTELY"] ++ acc, stack, context, comb__line, comb__offset + 8)
+  end
+
+  defp parse__136(<<"HOURLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__137(rest, ["HOURLY"] ++ acc, stack, context, comb__line, comb__offset + 6)
+  end
+
+  defp parse__136(<<"DAILY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__137(rest, ["DAILY"] ++ acc, stack, context, comb__line, comb__offset + 5)
+  end
+
+  defp parse__136(<<"WEEKLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__137(rest, ["WEEKLY"] ++ acc, stack, context, comb__line, comb__offset + 6)
+  end
+
+  defp parse__136(<<"MONTHLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__137(rest, ["MONTHLY"] ++ acc, stack, context, comb__line, comb__offset + 7)
+  end
+
+  defp parse__136(<<"YEARLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__137(rest, ["YEARLY"] ++ acc, stack, context, comb__line, comb__offset + 6)
+  end
+
+  defp parse__136(rest, acc, stack, context, line, offset) do
+    parse__134(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__137(rest, acc, [_, previous_acc | stack], context, line, offset) do
     parse__2(rest, acc ++ previous_acc, stack, context, line, offset)
   end
 
   defp parse__2(rest, acc, stack, context, line, offset) do
-    parse__120(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
+    parse__139(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
   end
 
-  defp parse__120(<<";", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__121(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__139(<<";", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__140(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__120(rest, acc, stack, context, line, offset) do
-    parse__119(rest, acc, stack, context, line, offset)
+  defp parse__139(rest, acc, stack, context, line, offset) do
+    parse__138(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__121(rest, acc, stack, context, line, offset) do
-    parse__236(rest, [], [{rest, context, line, offset}, acc | stack], context, line, offset)
+  defp parse__140(rest, acc, stack, context, line, offset) do
+    parse__274(rest, [], [{rest, context, line, offset}, acc | stack], context, line, offset)
   end
 
-  defp parse__123(
+  defp parse__142(
          <<"BYMONTHDAY", "=", rest::binary>>,
          acc,
          stack,
@@ -3679,540 +3814,540 @@ defmodule CalendarRecurrence.RRULE.Parser do
          comb__line,
          comb__offset
        ) do
-    parse__124(rest, ["BYMONTHDAY"] ++ acc, stack, context, comb__line, comb__offset + 11)
+    parse__143(rest, ["BYMONTHDAY"] ++ acc, stack, context, comb__line, comb__offset + 11)
   end
 
-  defp parse__123(rest, _acc, stack, context, line, offset) do
+  defp parse__142(rest, _acc, stack, context, line, offset) do
     [_, acc | stack] = stack
-    parse__119(rest, acc, stack, context, line, offset)
+    parse__138(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__124(rest, acc, stack, context, line, offset) do
-    parse__125(rest, [], [acc | stack], context, line, offset)
+  defp parse__143(rest, acc, stack, context, line, offset) do
+    parse__144(rest, [], [acc | stack], context, line, offset)
   end
 
-  defp parse__125(<<"-31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-31"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-31"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-30"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-30"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-29"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-29"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-28"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-28"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-27"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-27"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-26"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-26"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-25"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-25"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-24"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-24"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-23"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-23"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-22"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-22"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-21"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-21"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-20"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-20"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-19"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-19"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-18"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-18"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-17"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-17"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-16"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-16"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-15"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-15"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-14"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-14"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-13"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-13"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-12"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-12"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-11"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-11"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-10"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__144(<<"-10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-10"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__125(<<"-9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-9"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"-9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-9"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"-8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-8"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"-8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-8"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"-7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-7"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"-7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-7"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"-6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-6"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"-6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-6"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"-5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-5"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"-5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-5"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"-4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-4"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"-4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-4"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"-3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-3"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"-3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-3"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"-2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-2"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"-2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-2"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"-1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["-1"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"-1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["-1"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["31"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["31"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["30"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["30"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["29"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["29"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["28"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["28"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["27"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["27"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["26"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["26"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["25"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["25"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["24"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["24"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["23"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["23"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["22"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["22"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["21"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["21"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["20"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["20"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["19"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["19"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["18"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["18"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["17"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["17"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["16"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["16"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["15"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["15"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["14"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["14"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["13"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["13"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["12"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["12"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["11"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["11"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["10"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__144(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["10"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__125(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["9"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__144(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["9"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__125(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["8"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__144(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["8"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__125(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["7"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__144(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["7"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__125(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["6"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__144(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["6"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__125(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["5"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__144(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["5"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__125(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["4"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__144(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["4"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__125(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["3"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__144(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["3"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__125(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["2"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__144(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["2"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__125(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__126(rest, ["1"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__144(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__145(rest, ["1"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__125(rest, _acc, stack, context, line, offset) do
+  defp parse__144(rest, _acc, stack, context, line, offset) do
     [_, _, acc | stack] = stack
-    parse__119(rest, acc, stack, context, line, offset)
+    parse__138(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__126(rest, acc, stack, context, line, offset) do
-    parse__128(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
+  defp parse__145(rest, acc, stack, context, line, offset) do
+    parse__147(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
   end
 
-  defp parse__128(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__129(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__147(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__148(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__128(rest, acc, stack, context, line, offset) do
-    parse__127(rest, acc, stack, context, line, offset)
+  defp parse__147(rest, acc, stack, context, line, offset) do
+    parse__146(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__129(<<"-31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-31"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-31"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-30"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-30"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-29"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-29"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-28"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-28"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-27"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-27"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-26"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-26"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-25"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-25"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-24"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-24"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-23"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-23"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-22"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-22"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-21"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-21"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-20"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-20"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-19"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-19"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-18"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-18"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-17"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-17"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-16"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-16"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-15"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-15"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-14"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-14"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-13"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-13"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-12"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-12"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-11"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-11"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-10"] ++ acc, stack, context, comb__line, comb__offset + 3)
+  defp parse__148(<<"-10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-10"] ++ acc, stack, context, comb__line, comb__offset + 3)
   end
 
-  defp parse__129(<<"-9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-9"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"-9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-9"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"-8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-8"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"-8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-8"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"-7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-7"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"-7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-7"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"-6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-6"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"-6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-6"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"-5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-5"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"-5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-5"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"-4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-4"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"-4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-4"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"-3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-3"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"-3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-3"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"-2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-2"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"-2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-2"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"-1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["-1"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"-1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["-1"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["31"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["31"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["30"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["30"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["29"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["29"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["28"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["28"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["27"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["27"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["26"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["26"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["25"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["25"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["24"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["24"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["23"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["23"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["22"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["22"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["21"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["21"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["20"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["20"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["19"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["19"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["18"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["18"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["17"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["17"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["16"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["16"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["15"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["15"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["14"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["14"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["13"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["13"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["12"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["12"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["11"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["11"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["10"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__148(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["10"] ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__129(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["9"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__148(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["9"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__129(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["8"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__148(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["8"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__129(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["7"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__148(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["7"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__129(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["6"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__148(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["6"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__129(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["5"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__148(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["5"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__129(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["4"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__148(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["4"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__129(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["3"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__148(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["3"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__129(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["2"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__148(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["2"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__129(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__130(rest, ["1"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__148(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__149(rest, ["1"] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__129(rest, acc, stack, context, line, offset) do
-    parse__127(rest, acc, stack, context, line, offset)
+  defp parse__148(rest, acc, stack, context, line, offset) do
+    parse__146(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__127(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
-    parse__131(rest, acc, stack, context, line, offset)
+  defp parse__146(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
+    parse__150(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__130(
+  defp parse__149(
          inner_rest,
          inner_acc,
          [{rest, acc, context, line, offset} | stack],
@@ -4222,7 +4357,7 @@ defmodule CalendarRecurrence.RRULE.Parser do
        ) do
     _ = {rest, acc, context, line, offset}
 
-    parse__128(
+    parse__147(
       inner_rest,
       [],
       [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
@@ -4232,150 +4367,3161 @@ defmodule CalendarRecurrence.RRULE.Parser do
     )
   end
 
-  defp parse__131(rest, user_acc, [acc | stack], context, line, offset) do
+  defp parse__150(rest, user_acc, [acc | stack], context, line, offset) do
     _ = user_acc
-    parse__132(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
+    parse__151(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
   end
 
-  defp parse__132(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__122(rest, acc ++ previous_acc, stack, context, line, offset)
+  defp parse__151(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__141(rest, acc ++ previous_acc, stack, context, line, offset)
   end
 
-  defp parse__133(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__123(rest, [], stack, context, line, offset)
+  defp parse__152(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__142(rest, [], stack, context, line, offset)
   end
 
-  defp parse__134(<<"BYMONTH", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__135(rest, ["BYMONTH"] ++ acc, stack, context, comb__line, comb__offset + 8)
+  defp parse__153(<<"BYMONTH", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__154(rest, ["BYMONTH"] ++ acc, stack, context, comb__line, comb__offset + 8)
   end
 
-  defp parse__134(rest, acc, stack, context, line, offset) do
-    parse__133(rest, acc, stack, context, line, offset)
+  defp parse__153(rest, acc, stack, context, line, offset) do
+    parse__152(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__135(rest, acc, stack, context, line, offset) do
-    parse__136(rest, [], [acc | stack], context, line, offset)
+  defp parse__154(rest, acc, stack, context, line, offset) do
+    parse__155(rest, [], [acc | stack], context, line, offset)
   end
 
-  defp parse__136(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__137(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__155(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__156(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__136(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__137(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__155(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__156(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__136(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__137(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__155(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__156(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__136(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__137(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__155(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__156(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__136(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__137(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__155(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__156(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__136(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__137(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__155(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__156(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__136(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__137(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__155(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__156(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__136(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__137(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__155(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__156(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__136(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__137(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__155(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__156(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__136(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__137(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__155(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__156(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__136(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__137(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__155(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__156(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__136(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__137(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__155(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__156(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__136(rest, _acc, stack, context, line, offset) do
+  defp parse__155(rest, _acc, stack, context, line, offset) do
     [acc | stack] = stack
-    parse__133(rest, acc, stack, context, line, offset)
+    parse__152(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__137(rest, acc, stack, context, line, offset) do
-    parse__139(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
+  defp parse__156(rest, acc, stack, context, line, offset) do
+    parse__158(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
   end
 
-  defp parse__139(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__140(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__158(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__159(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__139(rest, acc, stack, context, line, offset) do
-    parse__138(rest, acc, stack, context, line, offset)
+  defp parse__158(rest, acc, stack, context, line, offset) do
+    parse__157(rest, acc, stack, context, line, offset)
   end
 
-  defp parse__140(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__141(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__159(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__160(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__140(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__141(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__159(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__160(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__140(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__141(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__159(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__160(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__140(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__141(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__159(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__160(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__140(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__141(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__159(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__160(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__140(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__141(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__159(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__160(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__140(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__141(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__159(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__160(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__140(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__141(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__159(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__160(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__140(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__141(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
+  defp parse__159(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__160(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
   end
 
-  defp parse__140(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__141(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__159(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__160(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__140(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__141(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__159(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__160(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__140(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__141(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  defp parse__159(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__160(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
   end
 
-  defp parse__140(rest, acc, stack, context, line, offset) do
-    parse__138(rest, acc, stack, context, line, offset)
+  defp parse__159(rest, acc, stack, context, line, offset) do
+    parse__157(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__157(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
+    parse__161(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__160(
+         inner_rest,
+         inner_acc,
+         [{rest, acc, context, line, offset} | stack],
+         inner_context,
+         inner_line,
+         inner_offset
+       ) do
+    _ = {rest, acc, context, line, offset}
+
+    parse__158(
+      inner_rest,
+      [],
+      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
+      inner_context,
+      inner_line,
+      inner_offset
+    )
+  end
+
+  defp parse__161(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+    parse__162(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
+  end
+
+  defp parse__162(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__141(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__163(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__153(rest, [], stack, context, line, offset)
+  end
+
+  defp parse__164(<<"BYDAY", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__165(rest, ["BYDAY"] ++ acc, stack, context, comb__line, comb__offset + 6)
+  end
+
+  defp parse__164(rest, acc, stack, context, line, offset) do
+    parse__163(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__165(rest, acc, stack, context, line, offset) do
+    parse__166(rest, [], [acc | stack], context, line, offset)
+  end
+
+  defp parse__166(rest, acc, stack, context, line, offset) do
+    parse__171(rest, [], [{rest, context, line, offset}, acc | stack], context, line, offset)
+  end
+
+  defp parse__168(<<"SU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__169(rest, ["SU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__168(<<"MO", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__169(rest, ["MO"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__168(<<"TU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__169(rest, ["TU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__168(<<"WE", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__169(rest, ["WE"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__168(<<"TH", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__169(rest, ["TH"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__168(<<"FR", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__169(rest, ["FR"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__168(<<"SA", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__169(rest, ["SA"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__168(rest, _acc, stack, context, line, offset) do
+    [_, _, acc | stack] = stack
+    parse__163(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__169(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__167(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__170(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__168(rest, [], stack, context, line, offset)
+  end
+
+  defp parse__171(rest, acc, stack, context, line, offset) do
+    parse__172(rest, [], [acc | stack], context, line, offset)
+  end
+
+  defp parse__172(<<"-", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__173(rest, ["-"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__172(<<"+", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__173(rest, ["+"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__172(<<rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__173(rest, ["+"] ++ acc, stack, context, comb__line, comb__offset)
+  end
+
+  defp parse__172(rest, _acc, stack, context, line, offset) do
+    [acc | stack] = stack
+    parse__170(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__173(rest, acc, stack, context, line, offset) do
+    parse__174(rest, [], [acc | stack], context, line, offset)
+  end
+
+  defp parse__174(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 do
+    parse__175(rest, [x0 - 48] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__174(rest, _acc, stack, context, line, offset) do
+    [_, acc | stack] = stack
+    parse__170(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__175(rest, acc, stack, context, line, offset) do
+    parse__177(rest, acc, [1 | stack], context, line, offset)
+  end
+
+  defp parse__177(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 do
+    parse__178(rest, [x0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__177(rest, acc, stack, context, line, offset) do
+    parse__176(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__176(rest, acc, [_ | stack], context, line, offset) do
+    parse__179(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__178(rest, acc, [1 | stack], context, line, offset) do
+    parse__179(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__178(rest, acc, [count | stack], context, line, offset) do
+    parse__177(rest, acc, [count - 1 | stack], context, line, offset)
+  end
+
+  defp parse__179(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+
+    parse__180(
+      rest,
+      (
+        [head | tail] = :lists.reverse(user_acc)
+        [:lists.foldl(fn x, acc -> x - 48 + acc * 10 end, head, tail)]
+      ) ++ acc,
+      stack,
+      context,
+      line,
+      offset
+    )
+  end
+
+  defp parse__180(<<"SU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__181(rest, ["SU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__180(<<"MO", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__181(rest, ["MO"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__180(<<"TU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__181(rest, ["TU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__180(<<"WE", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__181(rest, ["WE"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__180(<<"TH", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__181(rest, ["TH"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__180(<<"FR", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__181(rest, ["FR"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__180(<<"SA", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__181(rest, ["SA"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__180(rest, _acc, stack, context, line, offset) do
+    [acc | stack] = stack
+    parse__170(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__181(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+    parse__182(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
+  end
+
+  defp parse__182(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__167(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__167(rest, acc, stack, context, line, offset) do
+    parse__184(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
+  end
+
+  defp parse__184(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__185(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__184(rest, acc, stack, context, line, offset) do
+    parse__183(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__185(rest, acc, stack, context, line, offset) do
+    parse__190(rest, [], [{rest, context, line, offset}, acc | stack], context, line, offset)
+  end
+
+  defp parse__187(<<"SU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__188(rest, ["SU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__187(<<"MO", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__188(rest, ["MO"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__187(<<"TU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__188(rest, ["TU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__187(<<"WE", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__188(rest, ["WE"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__187(<<"TH", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__188(rest, ["TH"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__187(<<"FR", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__188(rest, ["FR"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__187(<<"SA", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__188(rest, ["SA"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__187(rest, _acc, stack, context, line, offset) do
+    [_, acc | stack] = stack
+    parse__183(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__188(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__186(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__189(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__187(rest, [], stack, context, line, offset)
+  end
+
+  defp parse__190(rest, acc, stack, context, line, offset) do
+    parse__191(rest, [], [acc | stack], context, line, offset)
+  end
+
+  defp parse__191(<<"-", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__192(rest, ["-"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__191(<<"+", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__192(rest, ["+"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__191(<<rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__192(rest, ["+"] ++ acc, stack, context, comb__line, comb__offset)
+  end
+
+  defp parse__191(rest, _acc, stack, context, line, offset) do
+    [acc | stack] = stack
+    parse__189(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__192(rest, acc, stack, context, line, offset) do
+    parse__193(rest, [], [acc | stack], context, line, offset)
+  end
+
+  defp parse__193(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 do
+    parse__194(rest, [x0 - 48] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__193(rest, _acc, stack, context, line, offset) do
+    [_, acc | stack] = stack
+    parse__189(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__194(rest, acc, stack, context, line, offset) do
+    parse__196(rest, acc, [1 | stack], context, line, offset)
+  end
+
+  defp parse__196(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 do
+    parse__197(rest, [x0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__196(rest, acc, stack, context, line, offset) do
+    parse__195(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__195(rest, acc, [_ | stack], context, line, offset) do
+    parse__198(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__197(rest, acc, [1 | stack], context, line, offset) do
+    parse__198(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__197(rest, acc, [count | stack], context, line, offset) do
+    parse__196(rest, acc, [count - 1 | stack], context, line, offset)
+  end
+
+  defp parse__198(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+
+    parse__199(
+      rest,
+      (
+        [head | tail] = :lists.reverse(user_acc)
+        [:lists.foldl(fn x, acc -> x - 48 + acc * 10 end, head, tail)]
+      ) ++ acc,
+      stack,
+      context,
+      line,
+      offset
+    )
+  end
+
+  defp parse__199(<<"SU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__200(rest, ["SU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__199(<<"MO", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__200(rest, ["MO"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__199(<<"TU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__200(rest, ["TU"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__199(<<"WE", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__200(rest, ["WE"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__199(<<"TH", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__200(rest, ["TH"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__199(<<"FR", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__200(rest, ["FR"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__199(<<"SA", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__200(rest, ["SA"] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__199(rest, _acc, stack, context, line, offset) do
+    [acc | stack] = stack
+    parse__189(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__200(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+    parse__201(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
+  end
+
+  defp parse__201(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__186(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__183(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
+    parse__202(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__186(
+         inner_rest,
+         inner_acc,
+         [{rest, acc, context, line, offset} | stack],
+         inner_context,
+         inner_line,
+         inner_offset
+       ) do
+    _ = {rest, acc, context, line, offset}
+
+    parse__184(
+      inner_rest,
+      [],
+      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
+      inner_context,
+      inner_line,
+      inner_offset
+    )
+  end
+
+  defp parse__202(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+    parse__203(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
+  end
+
+  defp parse__203(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__141(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__204(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__164(rest, [], stack, context, line, offset)
+  end
+
+  defp parse__205(<<"BYHOUR", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__206(rest, ["BYHOUR"] ++ acc, stack, context, comb__line, comb__offset + 7)
+  end
+
+  defp parse__205(rest, acc, stack, context, line, offset) do
+    parse__204(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__206(rest, acc, stack, context, line, offset) do
+    parse__207(rest, [], [acc | stack], context, line, offset)
+  end
+
+  defp parse__207(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__207(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__207(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__207(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__207(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__207(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__207(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__207(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__207(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__207(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__207(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__207(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__207(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__207(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__207(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__207(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__207(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__207(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__207(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__207(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__207(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__207(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__207(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__207(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__208(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__207(rest, _acc, stack, context, line, offset) do
+    [acc | stack] = stack
+    parse__204(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__208(rest, acc, stack, context, line, offset) do
+    parse__210(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
+  end
+
+  defp parse__210(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__211(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__210(rest, acc, stack, context, line, offset) do
+    parse__209(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__211(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__211(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__211(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__211(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__211(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__211(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__211(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__211(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__211(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__211(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__211(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__211(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__211(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__211(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__211(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__211(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__211(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__211(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__211(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__211(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__211(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__211(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__211(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__211(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__212(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__211(rest, acc, stack, context, line, offset) do
+    parse__209(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__209(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
+    parse__213(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__212(
+         inner_rest,
+         inner_acc,
+         [{rest, acc, context, line, offset} | stack],
+         inner_context,
+         inner_line,
+         inner_offset
+       ) do
+    _ = {rest, acc, context, line, offset}
+
+    parse__210(
+      inner_rest,
+      [],
+      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
+      inner_context,
+      inner_line,
+      inner_offset
+    )
+  end
+
+  defp parse__213(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+    parse__214(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
+  end
+
+  defp parse__214(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__141(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__215(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__205(rest, [], stack, context, line, offset)
+  end
+
+  defp parse__216(
+         <<"BYMINUTE", "=", rest::binary>>,
+         acc,
+         stack,
+         context,
+         comb__line,
+         comb__offset
+       ) do
+    parse__217(rest, ["BYMINUTE"] ++ acc, stack, context, comb__line, comb__offset + 9)
+  end
+
+  defp parse__216(rest, acc, stack, context, line, offset) do
+    parse__215(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__217(rest, acc, stack, context, line, offset) do
+    parse__218(rest, [], [acc | stack], context, line, offset)
+  end
+
+  defp parse__218(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__218(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__218(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__218(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__218(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__218(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__218(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__218(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__218(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__218(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__218(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__219(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__218(rest, _acc, stack, context, line, offset) do
+    [acc | stack] = stack
+    parse__215(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__219(rest, acc, stack, context, line, offset) do
+    parse__221(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
+  end
+
+  defp parse__221(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__222(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__221(rest, acc, stack, context, line, offset) do
+    parse__220(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__222(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__222(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__222(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__222(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__222(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__222(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__222(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__222(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__222(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__222(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__222(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__223(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__222(rest, acc, stack, context, line, offset) do
+    parse__220(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__220(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
+    parse__224(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__223(
+         inner_rest,
+         inner_acc,
+         [{rest, acc, context, line, offset} | stack],
+         inner_context,
+         inner_line,
+         inner_offset
+       ) do
+    _ = {rest, acc, context, line, offset}
+
+    parse__221(
+      inner_rest,
+      [],
+      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
+      inner_context,
+      inner_line,
+      inner_offset
+    )
+  end
+
+  defp parse__224(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+    parse__225(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
+  end
+
+  defp parse__225(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__141(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__226(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__216(rest, [], stack, context, line, offset)
+  end
+
+  defp parse__227(
+         <<"BYSECOND", "=", rest::binary>>,
+         acc,
+         stack,
+         context,
+         comb__line,
+         comb__offset
+       ) do
+    parse__228(rest, ["BYSECOND"] ++ acc, stack, context, comb__line, comb__offset + 9)
+  end
+
+  defp parse__227(rest, acc, stack, context, line, offset) do
+    parse__226(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__228(rest, acc, stack, context, line, offset) do
+    parse__229(rest, [], [acc | stack], context, line, offset)
+  end
+
+  defp parse__229(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__229(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__229(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__229(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__229(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__229(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__229(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__229(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__229(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__229(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__229(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__230(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__229(rest, _acc, stack, context, line, offset) do
+    [acc | stack] = stack
+    parse__226(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__230(rest, acc, stack, context, line, offset) do
+    parse__232(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
+  end
+
+  defp parse__232(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__233(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__232(rest, acc, stack, context, line, offset) do
+    parse__231(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__233(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__233(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__233(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__233(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__233(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__233(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__233(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__233(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__233(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__233(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__233(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__234(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__233(rest, acc, stack, context, line, offset) do
+    parse__231(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__231(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
+    parse__235(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__234(
+         inner_rest,
+         inner_acc,
+         [{rest, acc, context, line, offset} | stack],
+         inner_context,
+         inner_line,
+         inner_offset
+       ) do
+    _ = {rest, acc, context, line, offset}
+
+    parse__232(
+      inner_rest,
+      [],
+      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
+      inner_context,
+      inner_line,
+      inner_offset
+    )
+  end
+
+  defp parse__235(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+    parse__236(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
+  end
+
+  defp parse__236(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__141(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__237(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__227(rest, [], stack, context, line, offset)
+  end
+
+  defp parse__238(
+         <<"INTERVAL", "=", rest::binary>>,
+         acc,
+         stack,
+         context,
+         comb__line,
+         comb__offset
+       ) do
+    parse__239(rest, ["INTERVAL"] ++ acc, stack, context, comb__line, comb__offset + 9)
+  end
+
+  defp parse__238(rest, acc, stack, context, line, offset) do
+    parse__237(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__239(rest, acc, stack, context, line, offset) do
+    parse__240(rest, [], [acc | stack], context, line, offset)
+  end
+
+  defp parse__240(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 do
+    parse__241(rest, [x0 - 48] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__240(rest, _acc, stack, context, line, offset) do
+    [acc | stack] = stack
+    parse__237(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__241(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 do
+    parse__243(rest, [x0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__241(rest, acc, stack, context, line, offset) do
+    parse__242(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__243(rest, acc, stack, context, line, offset) do
+    parse__241(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__242(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+
+    parse__244(
+      rest,
+      (
+        [head | tail] = :lists.reverse(user_acc)
+        [:lists.foldl(fn x, acc -> x - 48 + acc * 10 end, head, tail)]
+      ) ++ acc,
+      stack,
+      context,
+      line,
+      offset
+    )
+  end
+
+  defp parse__244(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__141(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__245(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__238(rest, [], stack, context, line, offset)
+  end
+
+  defp parse__246(<<"COUNT", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__247(rest, ["COUNT"] ++ acc, stack, context, comb__line, comb__offset + 6)
+  end
+
+  defp parse__246(rest, acc, stack, context, line, offset) do
+    parse__245(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__247(rest, acc, stack, context, line, offset) do
+    parse__248(rest, [], [acc | stack], context, line, offset)
+  end
+
+  defp parse__248(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 do
+    parse__249(rest, [x0 - 48] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__248(rest, _acc, stack, context, line, offset) do
+    [acc | stack] = stack
+    parse__245(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__249(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 do
+    parse__251(rest, [x0] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__249(rest, acc, stack, context, line, offset) do
+    parse__250(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__251(rest, acc, stack, context, line, offset) do
+    parse__249(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__250(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+
+    parse__252(
+      rest,
+      (
+        [head | tail] = :lists.reverse(user_acc)
+        [:lists.foldl(fn x, acc -> x - 48 + acc * 10 end, head, tail)]
+      ) ++ acc,
+      stack,
+      context,
+      line,
+      offset
+    )
+  end
+
+  defp parse__252(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__141(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__253(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__246(rest, [], stack, context, line, offset)
+  end
+
+  defp parse__254(<<"UNTIL", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__255(rest, ["UNTIL"] ++ acc, stack, context, comb__line, comb__offset + 6)
+  end
+
+  defp parse__254(rest, acc, stack, context, line, offset) do
+    parse__253(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__255(rest, acc, stack, context, line, offset) do
+    parse__256(rest, [], [acc | stack], context, line, offset)
+  end
+
+  defp parse__256(rest, acc, stack, context, line, offset) do
+    parse__263(rest, [], [{rest, context, line, offset}, acc | stack], context, line, offset)
+  end
+
+  defp parse__258(<<x0, x1, x2, x3, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 and (x1 >= 48 and x1 <= 57) and (x2 >= 48 and x2 <= 57) and
+              (x3 >= 48 and x3 <= 57) do
+    parse__259(
+      rest,
+      [x3 - 48 + (x2 - 48) * 10 + (x1 - 48) * 100 + (x0 - 48) * 1000] ++ acc,
+      stack,
+      context,
+      comb__line,
+      comb__offset + 4
+    )
+  end
+
+  defp parse__258(rest, _acc, stack, context, line, offset) do
+    [_, _, acc | stack] = stack
+    parse__253(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__259(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__260(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__259(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__260(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__259(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__260(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__259(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__260(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__259(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__260(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__259(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__260(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__259(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__260(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__259(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__260(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__259(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__260(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__259(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__260(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__259(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__260(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__259(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__260(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__259(rest, _acc, stack, context, line, offset) do
+    [_, _, acc | stack] = stack
+    parse__253(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__260(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__261(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__260(rest, _acc, stack, context, line, offset) do
+    [_, _, acc | stack] = stack
+    parse__253(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__261(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__257(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__262(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__258(rest, [], stack, context, line, offset)
+  end
+
+  defp parse__263(<<x0, x1, x2, x3, rest::binary>>, acc, stack, context, comb__line, comb__offset)
+       when x0 >= 48 and x0 <= 57 and (x1 >= 48 and x1 <= 57) and (x2 >= 48 and x2 <= 57) and
+              (x3 >= 48 and x3 <= 57) do
+    parse__264(
+      rest,
+      [x3 - 48 + (x2 - 48) * 10 + (x1 - 48) * 100 + (x0 - 48) * 1000] ++ acc,
+      stack,
+      context,
+      comb__line,
+      comb__offset + 4
+    )
+  end
+
+  defp parse__263(rest, acc, stack, context, line, offset) do
+    parse__262(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__264(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__265(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__264(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__265(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__264(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__265(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__264(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__265(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__264(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__265(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__264(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__265(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__264(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__265(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__264(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__265(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__264(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__265(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__264(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__265(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__264(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__265(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__264(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__265(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__264(rest, acc, stack, context, line, offset) do
+    parse__262(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__265(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__266(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__265(rest, acc, stack, context, line, offset) do
+    parse__262(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__266(<<"T", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__267(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__266(rest, acc, stack, context, line, offset) do
+    parse__262(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__267(<<"00", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__268(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__267(rest, acc, stack, context, line, offset) do
+    parse__262(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__268(<<"00", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__269(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__268(rest, acc, stack, context, line, offset) do
+    parse__262(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__269(<<"00", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__270(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
+  end
+
+  defp parse__269(rest, acc, stack, context, line, offset) do
+    parse__262(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__270(<<"Z", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__271(rest, ["Z"] ++ acc, stack, context, comb__line, comb__offset + 1)
+  end
+
+  defp parse__270(<<rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__271(rest, [] ++ acc, stack, context, comb__line, comb__offset)
+  end
+
+  defp parse__271(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__257(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__257(rest, user_acc, [acc | stack], context, line, offset) do
+    _ = user_acc
+    parse__272(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
+  end
+
+  defp parse__272(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__141(rest, acc ++ previous_acc, stack, context, line, offset)
+  end
+
+  defp parse__273(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
+    parse__254(rest, [], stack, context, line, offset)
+  end
+
+  defp parse__274(<<"FREQ", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__275(rest, ["FREQ"] ++ acc, stack, context, comb__line, comb__offset + 5)
+  end
+
+  defp parse__274(rest, acc, stack, context, line, offset) do
+    parse__273(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__275(<<"SECONDLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__276(rest, ["SECONDLY"] ++ acc, stack, context, comb__line, comb__offset + 8)
+  end
+
+  defp parse__275(<<"MINUTELY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__276(rest, ["MINUTELY"] ++ acc, stack, context, comb__line, comb__offset + 8)
+  end
+
+  defp parse__275(<<"HOURLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__276(rest, ["HOURLY"] ++ acc, stack, context, comb__line, comb__offset + 6)
+  end
+
+  defp parse__275(<<"DAILY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__276(rest, ["DAILY"] ++ acc, stack, context, comb__line, comb__offset + 5)
+  end
+
+  defp parse__275(<<"WEEKLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__276(rest, ["WEEKLY"] ++ acc, stack, context, comb__line, comb__offset + 6)
+  end
+
+  defp parse__275(<<"MONTHLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__276(rest, ["MONTHLY"] ++ acc, stack, context, comb__line, comb__offset + 7)
+  end
+
+  defp parse__275(<<"YEARLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
+    parse__276(rest, ["YEARLY"] ++ acc, stack, context, comb__line, comb__offset + 6)
+  end
+
+  defp parse__275(rest, acc, stack, context, line, offset) do
+    parse__273(rest, acc, stack, context, line, offset)
+  end
+
+  defp parse__276(rest, acc, [_, previous_acc | stack], context, line, offset) do
+    parse__141(rest, acc ++ previous_acc, stack, context, line, offset)
   end
 
   defp parse__138(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
-    parse__142(rest, acc, stack, context, line, offset)
+    parse__277(rest, acc, stack, context, line, offset)
   end
 
   defp parse__141(
@@ -4398,2888 +7544,12 @@ defmodule CalendarRecurrence.RRULE.Parser do
     )
   end
 
-  defp parse__142(rest, user_acc, [acc | stack], context, line, offset) do
+  defp parse__277(rest, user_acc, [acc | stack], context, line, offset) do
     _ = user_acc
-    parse__143(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
+    parse__278(rest, [to_map(:lists.reverse(user_acc))] ++ acc, stack, context, line, offset)
   end
 
-  defp parse__143(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__122(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__144(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__134(rest, [], stack, context, line, offset)
-  end
-
-  defp parse__145(<<"BYDAY", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__146(rest, ["BYDAY"] ++ acc, stack, context, comb__line, comb__offset + 6)
-  end
-
-  defp parse__145(rest, acc, stack, context, line, offset) do
-    parse__144(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__146(rest, acc, stack, context, line, offset) do
-    parse__147(rest, [], [acc | stack], context, line, offset)
-  end
-
-  defp parse__147(<<"SU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__148(rest, ["SU"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__147(<<"MO", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__148(rest, ["MO"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__147(<<"TU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__148(rest, ["TU"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__147(<<"WE", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__148(rest, ["WE"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__147(<<"TH", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__148(rest, ["TH"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__147(<<"FR", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__148(rest, ["FR"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__147(<<"SA", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__148(rest, ["SA"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__147(rest, _acc, stack, context, line, offset) do
-    [acc | stack] = stack
-    parse__144(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__148(rest, acc, stack, context, line, offset) do
-    parse__150(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
-  end
-
-  defp parse__150(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__151(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__150(rest, acc, stack, context, line, offset) do
-    parse__149(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__151(<<"SU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__152(rest, ["SU"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__151(<<"MO", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__152(rest, ["MO"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__151(<<"TU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__152(rest, ["TU"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__151(<<"WE", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__152(rest, ["WE"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__151(<<"TH", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__152(rest, ["TH"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__151(<<"FR", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__152(rest, ["FR"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__151(<<"SA", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__152(rest, ["SA"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__151(rest, acc, stack, context, line, offset) do
-    parse__149(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__149(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
-    parse__153(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__152(
-         inner_rest,
-         inner_acc,
-         [{rest, acc, context, line, offset} | stack],
-         inner_context,
-         inner_line,
-         inner_offset
-       ) do
-    _ = {rest, acc, context, line, offset}
-
-    parse__150(
-      inner_rest,
-      [],
-      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
-      inner_context,
-      inner_line,
-      inner_offset
-    )
-  end
-
-  defp parse__153(rest, user_acc, [acc | stack], context, line, offset) do
-    _ = user_acc
-    parse__154(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
-  end
-
-  defp parse__154(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__122(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__155(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__145(rest, [], stack, context, line, offset)
-  end
-
-  defp parse__156(<<"BYDAY", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__157(rest, ["BYDAY"] ++ acc, stack, context, comb__line, comb__offset + 6)
-  end
-
-  defp parse__156(rest, acc, stack, context, line, offset) do
-    parse__155(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__157(rest, acc, stack, context, line, offset) do
-    parse__158(rest, [], [acc | stack], context, line, offset)
-  end
-
-  defp parse__158(<<"SU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__159(rest, ["SU"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__158(<<"MO", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__159(rest, ["MO"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__158(<<"TU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__159(rest, ["TU"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__158(<<"WE", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__159(rest, ["WE"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__158(<<"TH", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__159(rest, ["TH"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__158(<<"FR", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__159(rest, ["FR"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__158(<<"SA", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__159(rest, ["SA"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__158(rest, _acc, stack, context, line, offset) do
-    [acc | stack] = stack
-    parse__155(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__159(rest, acc, stack, context, line, offset) do
-    parse__161(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
-  end
-
-  defp parse__161(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__162(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__161(rest, acc, stack, context, line, offset) do
-    parse__160(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__162(<<"SU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__163(rest, ["SU"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__162(<<"MO", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__163(rest, ["MO"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__162(<<"TU", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__163(rest, ["TU"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__162(<<"WE", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__163(rest, ["WE"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__162(<<"TH", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__163(rest, ["TH"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__162(<<"FR", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__163(rest, ["FR"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__162(<<"SA", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__163(rest, ["SA"] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__162(rest, acc, stack, context, line, offset) do
-    parse__160(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__160(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
-    parse__164(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__163(
-         inner_rest,
-         inner_acc,
-         [{rest, acc, context, line, offset} | stack],
-         inner_context,
-         inner_line,
-         inner_offset
-       ) do
-    _ = {rest, acc, context, line, offset}
-
-    parse__161(
-      inner_rest,
-      [],
-      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
-      inner_context,
-      inner_line,
-      inner_offset
-    )
-  end
-
-  defp parse__164(rest, user_acc, [acc | stack], context, line, offset) do
-    _ = user_acc
-    parse__165(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
-  end
-
-  defp parse__165(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__122(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__166(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__156(rest, [], stack, context, line, offset)
-  end
-
-  defp parse__167(<<"BYHOUR", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__168(rest, ["BYHOUR"] ++ acc, stack, context, comb__line, comb__offset + 7)
-  end
-
-  defp parse__167(rest, acc, stack, context, line, offset) do
-    parse__166(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__168(rest, acc, stack, context, line, offset) do
-    parse__169(rest, [], [acc | stack], context, line, offset)
-  end
-
-  defp parse__169(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__169(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__169(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__169(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__169(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__169(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__169(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__169(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__169(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__169(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__169(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__169(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__169(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__169(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__169(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__169(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__169(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__169(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__169(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__169(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__169(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__169(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__169(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__169(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__170(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__169(rest, _acc, stack, context, line, offset) do
-    [acc | stack] = stack
-    parse__166(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__170(rest, acc, stack, context, line, offset) do
-    parse__172(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
-  end
-
-  defp parse__172(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__173(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__172(rest, acc, stack, context, line, offset) do
-    parse__171(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__173(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__173(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__173(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__173(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__173(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__173(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__173(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__173(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__173(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__173(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__173(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__173(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__173(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__173(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__173(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__173(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__173(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__173(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__173(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__173(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__173(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__173(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__173(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__173(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__174(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__173(rest, acc, stack, context, line, offset) do
-    parse__171(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__171(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
-    parse__175(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__174(
-         inner_rest,
-         inner_acc,
-         [{rest, acc, context, line, offset} | stack],
-         inner_context,
-         inner_line,
-         inner_offset
-       ) do
-    _ = {rest, acc, context, line, offset}
-
-    parse__172(
-      inner_rest,
-      [],
-      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
-      inner_context,
-      inner_line,
-      inner_offset
-    )
-  end
-
-  defp parse__175(rest, user_acc, [acc | stack], context, line, offset) do
-    _ = user_acc
-    parse__176(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
-  end
-
-  defp parse__176(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__122(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__177(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__167(rest, [], stack, context, line, offset)
-  end
-
-  defp parse__178(
-         <<"BYMINUTE", "=", rest::binary>>,
-         acc,
-         stack,
-         context,
-         comb__line,
-         comb__offset
-       ) do
-    parse__179(rest, ["BYMINUTE"] ++ acc, stack, context, comb__line, comb__offset + 9)
-  end
-
-  defp parse__178(rest, acc, stack, context, line, offset) do
-    parse__177(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__179(rest, acc, stack, context, line, offset) do
-    parse__180(rest, [], [acc | stack], context, line, offset)
-  end
-
-  defp parse__180(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__180(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__180(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__180(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__180(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__180(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__180(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__180(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__180(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__180(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__180(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__181(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__180(rest, _acc, stack, context, line, offset) do
-    [acc | stack] = stack
-    parse__177(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__181(rest, acc, stack, context, line, offset) do
-    parse__183(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
-  end
-
-  defp parse__183(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__184(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__183(rest, acc, stack, context, line, offset) do
-    parse__182(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__184(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__184(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__184(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__184(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__184(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__184(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__184(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__184(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__184(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__184(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__184(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__185(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__184(rest, acc, stack, context, line, offset) do
-    parse__182(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__182(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
-    parse__186(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__185(
-         inner_rest,
-         inner_acc,
-         [{rest, acc, context, line, offset} | stack],
-         inner_context,
-         inner_line,
-         inner_offset
-       ) do
-    _ = {rest, acc, context, line, offset}
-
-    parse__183(
-      inner_rest,
-      [],
-      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
-      inner_context,
-      inner_line,
-      inner_offset
-    )
-  end
-
-  defp parse__186(rest, user_acc, [acc | stack], context, line, offset) do
-    _ = user_acc
-    parse__187(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
-  end
-
-  defp parse__187(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__122(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__188(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__178(rest, [], stack, context, line, offset)
-  end
-
-  defp parse__189(
-         <<"BYSECOND", "=", rest::binary>>,
-         acc,
-         stack,
-         context,
-         comb__line,
-         comb__offset
-       ) do
-    parse__190(rest, ["BYSECOND"] ++ acc, stack, context, comb__line, comb__offset + 9)
-  end
-
-  defp parse__189(rest, acc, stack, context, line, offset) do
-    parse__188(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__190(rest, acc, stack, context, line, offset) do
-    parse__191(rest, [], [acc | stack], context, line, offset)
-  end
-
-  defp parse__191(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__191(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__191(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__191(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__191(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__191(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__191(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__191(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__191(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__191(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__191(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__192(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__191(rest, _acc, stack, context, line, offset) do
-    [acc | stack] = stack
-    parse__188(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__192(rest, acc, stack, context, line, offset) do
-    parse__194(rest, [], [{rest, acc, context, line, offset} | stack], context, line, offset)
-  end
-
-  defp parse__194(<<",", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__195(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__194(rest, acc, stack, context, line, offset) do
-    parse__193(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__195(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__195(<<"9", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__195(<<"8", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__195(<<"7", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__195(<<"6", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__195(<<"5", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__195(<<"4", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__195(<<"3", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__195(<<"2", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__195(<<"1", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__195(<<"0", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__196(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__195(rest, acc, stack, context, line, offset) do
-    parse__193(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__193(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
-    parse__197(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__196(
-         inner_rest,
-         inner_acc,
-         [{rest, acc, context, line, offset} | stack],
-         inner_context,
-         inner_line,
-         inner_offset
-       ) do
-    _ = {rest, acc, context, line, offset}
-
-    parse__194(
-      inner_rest,
-      [],
-      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
-      inner_context,
-      inner_line,
-      inner_offset
-    )
-  end
-
-  defp parse__197(rest, user_acc, [acc | stack], context, line, offset) do
-    _ = user_acc
-    parse__198(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
-  end
-
-  defp parse__198(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__122(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__199(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__189(rest, [], stack, context, line, offset)
-  end
-
-  defp parse__200(
-         <<"INTERVAL", "=", rest::binary>>,
-         acc,
-         stack,
-         context,
-         comb__line,
-         comb__offset
-       ) do
-    parse__201(rest, ["INTERVAL"] ++ acc, stack, context, comb__line, comb__offset + 9)
-  end
-
-  defp parse__200(rest, acc, stack, context, line, offset) do
-    parse__199(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__201(rest, acc, stack, context, line, offset) do
-    parse__202(rest, [], [acc | stack], context, line, offset)
-  end
-
-  defp parse__202(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
-       when x0 >= 48 and x0 <= 57 do
-    parse__203(rest, [x0 - 48] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__202(rest, _acc, stack, context, line, offset) do
-    [acc | stack] = stack
-    parse__199(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__203(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
-       when x0 >= 48 and x0 <= 57 do
-    parse__205(rest, [x0] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__203(rest, acc, stack, context, line, offset) do
-    parse__204(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__205(rest, acc, stack, context, line, offset) do
-    parse__203(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__204(rest, user_acc, [acc | stack], context, line, offset) do
-    _ = user_acc
-
-    parse__206(
-      rest,
-      (
-        [head | tail] = :lists.reverse(user_acc)
-        [:lists.foldl(fn x, acc -> x - 48 + acc * 10 end, head, tail)]
-      ) ++ acc,
-      stack,
-      context,
-      line,
-      offset
-    )
-  end
-
-  defp parse__206(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__122(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__207(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__200(rest, [], stack, context, line, offset)
-  end
-
-  defp parse__208(<<"COUNT", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__209(rest, ["COUNT"] ++ acc, stack, context, comb__line, comb__offset + 6)
-  end
-
-  defp parse__208(rest, acc, stack, context, line, offset) do
-    parse__207(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__209(rest, acc, stack, context, line, offset) do
-    parse__210(rest, [], [acc | stack], context, line, offset)
-  end
-
-  defp parse__210(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
-       when x0 >= 48 and x0 <= 57 do
-    parse__211(rest, [x0 - 48] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__210(rest, _acc, stack, context, line, offset) do
-    [acc | stack] = stack
-    parse__207(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__211(<<x0, rest::binary>>, acc, stack, context, comb__line, comb__offset)
-       when x0 >= 48 and x0 <= 57 do
-    parse__213(rest, [x0] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__211(rest, acc, stack, context, line, offset) do
-    parse__212(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__213(rest, acc, stack, context, line, offset) do
-    parse__211(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__212(rest, user_acc, [acc | stack], context, line, offset) do
-    _ = user_acc
-
-    parse__214(
-      rest,
-      (
-        [head | tail] = :lists.reverse(user_acc)
-        [:lists.foldl(fn x, acc -> x - 48 + acc * 10 end, head, tail)]
-      ) ++ acc,
-      stack,
-      context,
-      line,
-      offset
-    )
-  end
-
-  defp parse__214(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__122(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__215(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__208(rest, [], stack, context, line, offset)
-  end
-
-  defp parse__216(<<"UNTIL", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__217(rest, ["UNTIL"] ++ acc, stack, context, comb__line, comb__offset + 6)
-  end
-
-  defp parse__216(rest, acc, stack, context, line, offset) do
-    parse__215(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__217(rest, acc, stack, context, line, offset) do
-    parse__218(rest, [], [acc | stack], context, line, offset)
-  end
-
-  defp parse__218(rest, acc, stack, context, line, offset) do
-    parse__225(rest, [], [{rest, context, line, offset}, acc | stack], context, line, offset)
-  end
-
-  defp parse__220(<<x0, x1, x2, x3, rest::binary>>, acc, stack, context, comb__line, comb__offset)
-       when x0 >= 48 and x0 <= 57 and (x1 >= 48 and x1 <= 57) and (x2 >= 48 and x2 <= 57) and
-              (x3 >= 48 and x3 <= 57) do
-    parse__221(
-      rest,
-      [x3 - 48 + (x2 - 48) * 10 + (x1 - 48) * 100 + (x0 - 48) * 1000] ++ acc,
-      stack,
-      context,
-      comb__line,
-      comb__offset + 4
-    )
-  end
-
-  defp parse__220(rest, _acc, stack, context, line, offset) do
-    [_, _, acc | stack] = stack
-    parse__215(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__221(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__222(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__221(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__222(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__221(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__222(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__221(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__222(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__221(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__222(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__221(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__222(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__221(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__222(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__221(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__222(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__221(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__222(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__221(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__222(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__221(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__222(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__221(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__222(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__221(rest, _acc, stack, context, line, offset) do
-    [_, _, acc | stack] = stack
-    parse__215(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__222(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__223(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__222(rest, _acc, stack, context, line, offset) do
-    [_, _, acc | stack] = stack
-    parse__215(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__223(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__219(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__224(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__220(rest, [], stack, context, line, offset)
-  end
-
-  defp parse__225(<<x0, x1, x2, x3, rest::binary>>, acc, stack, context, comb__line, comb__offset)
-       when x0 >= 48 and x0 <= 57 and (x1 >= 48 and x1 <= 57) and (x2 >= 48 and x2 <= 57) and
-              (x3 >= 48 and x3 <= 57) do
-    parse__226(
-      rest,
-      [x3 - 48 + (x2 - 48) * 10 + (x1 - 48) * 100 + (x0 - 48) * 1000] ++ acc,
-      stack,
-      context,
-      comb__line,
-      comb__offset + 4
-    )
-  end
-
-  defp parse__225(rest, acc, stack, context, line, offset) do
-    parse__224(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__226(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__227(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__226(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__227(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__226(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__227(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__226(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__227(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__226(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__227(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__226(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__227(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__226(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__227(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__226(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__227(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__226(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__227(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__226(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__227(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__226(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__227(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__226(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__227(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__226(rest, acc, stack, context, line, offset) do
-    parse__224(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__227(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__228(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__227(rest, acc, stack, context, line, offset) do
-    parse__224(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__228(<<"T", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__229(rest, [] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__228(rest, acc, stack, context, line, offset) do
-    parse__224(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__229(<<"00", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__230(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__229(rest, acc, stack, context, line, offset) do
-    parse__224(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__230(<<"00", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__231(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__230(rest, acc, stack, context, line, offset) do
-    parse__224(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__231(<<"00", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [0] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"01", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [1] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"02", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [2] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"03", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [3] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"04", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [4] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"05", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [5] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"06", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [6] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"07", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"\a" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"08", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"\b" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"09", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"\t" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"10", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"\n" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"11", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"\v" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"12", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"\f" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"13", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"\r" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"14", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [14] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"15", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [15] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"16", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [16] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"17", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [17] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"18", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [18] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"19", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [19] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"20", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [20] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"21", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [21] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"22", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [22] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"23", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [23] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"24", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [24] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"25", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [25] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"26", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [26] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"27", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"\e" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"28", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [28] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"29", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [29] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"30", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [30] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"31", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, [31] ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"32", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c" " ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"33", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"!" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"34", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"\"" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"35", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"#" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"36", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"$" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"37", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"%" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"38", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"&" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"39", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"'" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"40", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"(" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"41", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c")" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"42", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"*" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"43", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"+" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"44", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"," ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"45", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"-" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"46", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"." ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"47", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"/" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"48", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"0" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"49", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"1" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"50", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"2" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"51", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"3" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"52", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"4" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"53", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"5" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"54", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"6" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"55", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"7" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"56", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"8" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"57", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c"9" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"58", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c":" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(<<"59", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__232(rest, ~c";" ++ acc, stack, context, comb__line, comb__offset + 2)
-  end
-
-  defp parse__231(rest, acc, stack, context, line, offset) do
-    parse__224(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__232(<<"Z", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__233(rest, ["Z"] ++ acc, stack, context, comb__line, comb__offset + 1)
-  end
-
-  defp parse__232(<<rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__233(rest, [] ++ acc, stack, context, comb__line, comb__offset)
-  end
-
-  defp parse__233(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__219(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__219(rest, user_acc, [acc | stack], context, line, offset) do
-    _ = user_acc
-    parse__234(rest, [:lists.reverse(user_acc)] ++ acc, stack, context, line, offset)
-  end
-
-  defp parse__234(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__122(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__235(_, _, [{rest, context, line, offset} | _] = stack, _, _, _) do
-    parse__216(rest, [], stack, context, line, offset)
-  end
-
-  defp parse__236(<<"FREQ", "=", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__237(rest, ["FREQ"] ++ acc, stack, context, comb__line, comb__offset + 5)
-  end
-
-  defp parse__236(rest, acc, stack, context, line, offset) do
-    parse__235(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__237(<<"SECONDLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__238(rest, ["SECONDLY"] ++ acc, stack, context, comb__line, comb__offset + 8)
-  end
-
-  defp parse__237(<<"MINUTELY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__238(rest, ["MINUTELY"] ++ acc, stack, context, comb__line, comb__offset + 8)
-  end
-
-  defp parse__237(<<"HOURLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__238(rest, ["HOURLY"] ++ acc, stack, context, comb__line, comb__offset + 6)
-  end
-
-  defp parse__237(<<"DAILY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__238(rest, ["DAILY"] ++ acc, stack, context, comb__line, comb__offset + 5)
-  end
-
-  defp parse__237(<<"WEEKLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__238(rest, ["WEEKLY"] ++ acc, stack, context, comb__line, comb__offset + 6)
-  end
-
-  defp parse__237(<<"MONTHLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__238(rest, ["MONTHLY"] ++ acc, stack, context, comb__line, comb__offset + 7)
-  end
-
-  defp parse__237(<<"YEARLY", rest::binary>>, acc, stack, context, comb__line, comb__offset) do
-    parse__238(rest, ["YEARLY"] ++ acc, stack, context, comb__line, comb__offset + 6)
-  end
-
-  defp parse__237(rest, acc, stack, context, line, offset) do
-    parse__235(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__238(rest, acc, [_, previous_acc | stack], context, line, offset) do
-    parse__122(rest, acc ++ previous_acc, stack, context, line, offset)
-  end
-
-  defp parse__119(_, _, [{rest, acc, context, line, offset} | stack], _, _, _) do
-    parse__239(rest, acc, stack, context, line, offset)
-  end
-
-  defp parse__122(
-         inner_rest,
-         inner_acc,
-         [{rest, acc, context, line, offset} | stack],
-         inner_context,
-         inner_line,
-         inner_offset
-       ) do
-    _ = {rest, acc, context, line, offset}
-
-    parse__120(
-      inner_rest,
-      [],
-      [{inner_rest, inner_acc ++ acc, inner_context, inner_line, inner_offset} | stack],
-      inner_context,
-      inner_line,
-      inner_offset
-    )
-  end
-
-  defp parse__239(rest, user_acc, [acc | stack], context, line, offset) do
-    _ = user_acc
-    parse__240(rest, [to_map(:lists.reverse(user_acc))] ++ acc, stack, context, line, offset)
-  end
-
-  defp parse__240(rest, acc, _stack, context, line, offset) do
+  defp parse__278(rest, acc, _stack, context, line, offset) do
     {:ok, acc, rest, context, line, offset}
   end
 
@@ -7318,6 +7588,8 @@ defmodule CalendarRecurrence.RRULE.Parser do
 
   defp cast_value(_, value), do: value
 
+  defp cast_byday(["+", n, day]), do: {n, cast_byday(day)}
+  defp cast_byday(["-", n, day]), do: {-n, cast_byday(day)}
   defp cast_byday("SU"), do: 7
   defp cast_byday("MO"), do: 1
   defp cast_byday("TU"), do: 2

--- a/lib/calendar_recurrence/rrule_parser.ex.exs
+++ b/lib/calendar_recurrence/rrule_parser.ex.exs
@@ -90,8 +90,11 @@ defmodule CalendarRecurrence.RRULE.Parser do
   hours = any_of(23..0//-1, &string(to_string(&1)))
   byhour = part("BYHOUR", non_empty_list(hours))
 
-  days = any_of(~w(SU MO TU WE TH FR SA), &string(to_string(&1)))
-  byday = part("BYDAY", non_empty_list(days))
+  day_name = any_of(~w(SU MO TU WE TH FR SA), &string(to_string(&1)))
+  ordinal_sign = choice([string("-"), string("+"), empty() |> replace("+")])
+  ordinal_byday = ordinal_sign |> concat(integer(min: 1, max: 2)) |> concat(day_name) |> wrap()
+  byday_item = choice([ordinal_byday, day_name])
+  byday = part("BYDAY", non_empty_list(byday_item))
 
   months = any_of(1..12, &string(to_string(&1)))
   bymonth = part("BYMONTH", non_empty_list(months))
@@ -115,7 +118,6 @@ defmodule CalendarRecurrence.RRULE.Parser do
       bysecond,
       byminute,
       byhour,
-      byday,
       byday,
       bymonth,
       bymonthday
@@ -165,6 +167,8 @@ defmodule CalendarRecurrence.RRULE.Parser do
 
   defp cast_value(_, value), do: value
 
+  defp cast_byday(["+", n, day]), do: {n, cast_byday(day)}
+  defp cast_byday(["-", n, day]), do: {-n, cast_byday(day)}
   defp cast_byday("SU"), do: 7
   defp cast_byday("MO"), do: 1
   defp cast_byday("TU"), do: 2

--- a/test/calendar_recurrence/rrule_test.exs
+++ b/test/calendar_recurrence/rrule_test.exs
@@ -661,5 +661,35 @@ defmodule CalendarRecurrence.RRULETest do
              ~D[2024-02-05],
              ~D[2024-03-04]
            ]
+
+    # FREQ=MONTHLY;BYDAY=-1FR → last Friday of every month (string round-trip)
+    assert Enum.take(RRULE.to_recurrence("FREQ=MONTHLY;BYDAY=-1FR", ~D[2024-01-26]), 4) == [
+             ~D[2024-01-26],
+             ~D[2024-02-23],
+             ~D[2024-03-29],
+             ~D[2024-04-26]
+           ]
+
+    # FREQ=MONTHLY;BYDAY=MO → every Monday of every month (string round-trip)
+    assert Enum.take(RRULE.to_recurrence("FREQ=MONTHLY;BYDAY=MO", ~D[2024-01-01]), 6) == [
+             ~D[2024-01-01],
+             ~D[2024-01-08],
+             ~D[2024-01-15],
+             ~D[2024-01-22],
+             ~D[2024-01-29],
+             ~D[2024-02-05]
+           ]
+  end
+
+  test "yearly BYDAY with BYMONTH (e.g., 2nd Sunday of March)" do
+    # FREQ=YEARLY;BYMONTH=3;BYDAY=2SU → second Sunday of March every year
+    {:ok, rrule} = RRULE.parse("FREQ=YEARLY;BYMONTH=3;BYDAY=2SU")
+    assert %RRULE{freq: :yearly, bymonth: [3], byday: [{2, 7}]} = rrule
+
+    assert Enum.take(RRULE.to_recurrence(rrule, ~D[2024-03-10]), 3) == [
+             ~D[2024-03-10],
+             ~D[2025-03-09],
+             ~D[2026-03-08]
+           ]
   end
 end

--- a/test/calendar_recurrence/rrule_test.exs
+++ b/test/calendar_recurrence/rrule_test.exs
@@ -679,6 +679,18 @@ defmodule CalendarRecurrence.RRULETest do
              ~D[2024-01-29],
              ~D[2024-02-05]
            ]
+
+    # Monthly BYDAY: start date doesn't match the rule (DTSTART is always emitted per RFC 5545)
+    # 2024-01-15 is a Monday but the 3rd Monday, not the 1st — start date is still included
+    assert Enum.take(
+             RRULE.to_recurrence(%RRULE{freq: :monthly, byday: [{1, 1}]}, ~D[2024-01-15]),
+             4
+           ) == [
+             ~D[2024-01-15],
+             ~D[2024-02-05],
+             ~D[2024-03-04],
+             ~D[2024-04-01]
+           ]
   end
 
   test "yearly BYDAY with BYMONTH (e.g., 2nd Sunday of March)" do

--- a/test/calendar_recurrence/rrule_test.exs
+++ b/test/calendar_recurrence/rrule_test.exs
@@ -70,6 +70,16 @@ defmodule CalendarRecurrence.RRULETest do
 
     # Weekly BYDAY regression
     {:ok, %RRULE{freq: :weekly, byday: [1, 2]}} = RRULE.parse("FREQ=WEEKLY;BYDAY=MO,TU")
+
+    # BYDAY ordinal boundary values (valid)
+    {:ok, %RRULE{byday: [{5, 1}]}} = RRULE.parse("FREQ=MONTHLY;BYDAY=5MO")
+    {:ok, %RRULE{byday: [{-5, 5}]}} = RRULE.parse("FREQ=MONTHLY;BYDAY=-5FR")
+
+    # BYDAY ordinal out of range
+    {:error, "invalid BYDAY ordinal 6" <> _} = RRULE.parse("FREQ=MONTHLY;BYDAY=6TU")
+    {:error, "invalid BYDAY ordinal 9" <> _} = RRULE.parse("FREQ=MONTHLY;BYDAY=9WE")
+    {:error, "invalid BYDAY ordinal 0" <> _} = RRULE.parse("FREQ=MONTHLY;BYDAY=0TH")
+    {:error, "invalid BYDAY ordinal -6" <> _} = RRULE.parse("FREQ=MONTHLY;BYDAY=-6FR")
   end
 
   test "to_string/1" do

--- a/test/calendar_recurrence/rrule_test.exs
+++ b/test/calendar_recurrence/rrule_test.exs
@@ -53,6 +53,20 @@ defmodule CalendarRecurrence.RRULETest do
     {:error, "expected string \"FREQ\", followed by" <> _} = RRULE.parse("bad")
 
     {:error, {:leftover, "foobar"}} = RRULE.parse("FREQ=DAILYfoobar")
+
+    # Monthly BYDAY with ordinal prefixes
+    {:ok, %RRULE{freq: :monthly, byday: [{1, 1}]}} = RRULE.parse("FREQ=MONTHLY;BYDAY=1MO")
+    {:ok, %RRULE{freq: :monthly, byday: [{-1, 5}]}} = RRULE.parse("FREQ=MONTHLY;BYDAY=-1FR")
+    {:ok, %RRULE{freq: :monthly, byday: [{2, 7}]}} = RRULE.parse("FREQ=MONTHLY;BYDAY=+2SU")
+
+    {:ok, %RRULE{freq: :monthly, byday: [{1, 1}, {-1, 5}]}} =
+      RRULE.parse("FREQ=MONTHLY;BYDAY=1MO,-1FR")
+
+    # Monthly BYDAY without ordinals (plain weekday)
+    {:ok, %RRULE{freq: :monthly, byday: [1]}} = RRULE.parse("FREQ=MONTHLY;BYDAY=MO")
+
+    # Weekly BYDAY regression
+    {:ok, %RRULE{freq: :weekly, byday: [1, 2]}} = RRULE.parse("FREQ=WEEKLY;BYDAY=MO,TU")
   end
 
   test "to_string/1" do
@@ -78,6 +92,13 @@ defmodule CalendarRecurrence.RRULETest do
 
     assert "FREQ=MONTHLY;BYMONTHDAY=5;BYMONTH=1,3,4" =
              to_string(%RRULE{freq: :monthly, bymonthday: [5], bymonth: [1, 3, 4]})
+
+    # Monthly BYDAY with ordinals
+    assert "FREQ=MONTHLY;BYDAY=1MO" = to_string(%RRULE{freq: :monthly, byday: [{1, 1}]})
+    assert "FREQ=MONTHLY;BYDAY=-1FR" = to_string(%RRULE{freq: :monthly, byday: [{-1, 5}]})
+
+    assert "FREQ=MONTHLY;BYDAY=1MO,-1FR" =
+             to_string(%RRULE{freq: :monthly, byday: [{1, 1}, {-1, 5}]})
   end
 
   test "to_recurrence/1" do
@@ -424,5 +445,113 @@ defmodule CalendarRecurrence.RRULETest do
                ~D[2019-03-30],
                ~D[2019-06-30]
              ]
+
+    # Monthly BYDAY: first Monday of every month
+    assert Enum.take(
+             RRULE.to_recurrence(%RRULE{freq: :monthly, byday: [{1, 1}]}, ~D[2024-01-01]),
+             4
+           ) == [
+             ~D[2024-01-01],
+             ~D[2024-02-05],
+             ~D[2024-03-04],
+             ~D[2024-04-01]
+           ]
+
+    # Monthly BYDAY: first Monday with DateTime
+    assert Enum.take(
+             RRULE.to_recurrence(
+               %RRULE{freq: :monthly, byday: [{1, 1}]},
+               ~U[2024-01-01 10:00:00Z]
+             ),
+             3
+           ) == [
+             ~U[2024-01-01 10:00:00Z],
+             ~U[2024-02-05 10:00:00Z],
+             ~U[2024-03-04 10:00:00Z]
+           ]
+
+    # Monthly BYDAY: last Friday of every month
+    assert Enum.take(
+             RRULE.to_recurrence(%RRULE{freq: :monthly, byday: [{-1, 5}]}, ~D[2024-01-26]),
+             4
+           ) == [
+             ~D[2024-01-26],
+             ~D[2024-02-23],
+             ~D[2024-03-29],
+             ~D[2024-04-26]
+           ]
+
+    # Monthly BYDAY: first Monday every 2 months
+    assert Enum.take(
+             RRULE.to_recurrence(
+               %RRULE{freq: :monthly, interval: 2, byday: [{1, 1}]},
+               ~D[2024-01-01]
+             ),
+             4
+           ) == [
+             ~D[2024-01-01],
+             ~D[2024-03-04],
+             ~D[2024-05-06],
+             ~D[2024-07-01]
+           ]
+
+    # Monthly BYDAY: 5th Monday (skips months without a 5th Monday)
+    assert Enum.take(
+             RRULE.to_recurrence(
+               %RRULE{freq: :monthly, byday: [{5, 1}], count: 3},
+               ~D[2024-01-29]
+             ),
+             3
+           ) == [
+             ~D[2024-01-29],
+             ~D[2024-04-29],
+             ~D[2024-07-29]
+           ]
+
+    # Monthly BYDAY: year boundary crossing
+    assert Enum.take(
+             RRULE.to_recurrence(%RRULE{freq: :monthly, byday: [{1, 1}]}, ~D[2024-12-02]),
+             3
+           ) == [
+             ~D[2024-12-02],
+             ~D[2025-01-06],
+             ~D[2025-02-03]
+           ]
+
+    # Monthly BYDAY: every Monday of every month (plain, no ordinal)
+    assert Enum.take(
+             RRULE.to_recurrence(%RRULE{freq: :monthly, byday: [1]}, ~D[2024-01-01]),
+             6
+           ) == [
+             ~D[2024-01-01],
+             ~D[2024-01-08],
+             ~D[2024-01-15],
+             ~D[2024-01-22],
+             ~D[2024-01-29],
+             ~D[2024-02-05]
+           ]
+
+    # Monthly BYDAY: multiple ordinal entries (first Monday and last Friday)
+    assert Enum.take(
+             RRULE.to_recurrence(
+               %RRULE{freq: :monthly, byday: [{1, 1}, {-1, 5}]},
+               ~D[2024-01-01]
+             ),
+             6
+           ) == [
+             ~D[2024-01-01],
+             ~D[2024-01-26],
+             ~D[2024-02-05],
+             ~D[2024-02-23],
+             ~D[2024-03-04],
+             ~D[2024-03-29]
+           ]
+
+    # Parse and recurrence round-trip
+    assert Enum.take(RRULE.to_recurrence("FREQ=MONTHLY;BYDAY=1MO", ~D[2024-01-01]), 3) == [
+             ~D[2024-01-01],
+             ~D[2024-02-05],
+             ~D[2024-03-04]
+           ]
   end
 end

--- a/test/calendar_recurrence/rrule_test.exs
+++ b/test/calendar_recurrence/rrule_test.exs
@@ -65,6 +65,9 @@ defmodule CalendarRecurrence.RRULETest do
     # Monthly BYDAY without ordinals (plain weekday)
     {:ok, %RRULE{freq: :monthly, byday: [1]}} = RRULE.parse("FREQ=MONTHLY;BYDAY=MO")
 
+    # Monthly BYDAY with multiple plain weekdays
+    {:ok, %RRULE{freq: :monthly, byday: [1, 5]}} = RRULE.parse("FREQ=MONTHLY;BYDAY=MO,FR")
+
     # Weekly BYDAY regression
     {:ok, %RRULE{freq: :weekly, byday: [1, 2]}} = RRULE.parse("FREQ=WEEKLY;BYDAY=MO,TU")
   end
@@ -99,6 +102,13 @@ defmodule CalendarRecurrence.RRULETest do
 
     assert "FREQ=MONTHLY;BYDAY=1MO,-1FR" =
              to_string(%RRULE{freq: :monthly, byday: [{1, 1}, {-1, 5}]})
+
+    # Plain monthly BYDAY
+    assert "FREQ=MONTHLY;BYDAY=MO" = to_string(%RRULE{freq: :monthly, byday: [1]})
+
+    # Parse -> to_string -> parse round-trip
+    {:ok, rrule} = RRULE.parse("FREQ=MONTHLY;BYDAY=1MO,-1FR")
+    assert {:ok, ^rrule} = RRULE.parse(to_string(rrule))
   end
 
   test "to_recurrence/1" do
@@ -470,6 +480,19 @@ defmodule CalendarRecurrence.RRULETest do
              ~U[2024-03-04 10:00:00Z]
            ]
 
+    # Monthly BYDAY: first Monday with NaiveDateTime
+    assert Enum.take(
+             RRULE.to_recurrence(
+               %RRULE{freq: :monthly, byday: [{1, 1}]},
+               ~N[2024-01-01 09:00:00]
+             ),
+             3
+           ) == [
+             ~N[2024-01-01 09:00:00],
+             ~N[2024-02-05 09:00:00],
+             ~N[2024-03-04 09:00:00]
+           ]
+
     # Monthly BYDAY: last Friday of every month
     assert Enum.take(
              RRULE.to_recurrence(%RRULE{freq: :monthly, byday: [{-1, 5}]}, ~D[2024-01-26]),
@@ -479,6 +502,17 @@ defmodule CalendarRecurrence.RRULETest do
              ~D[2024-02-23],
              ~D[2024-03-29],
              ~D[2024-04-26]
+           ]
+
+    # Monthly BYDAY: second-to-last Friday (-2)
+    assert Enum.take(
+             RRULE.to_recurrence(%RRULE{freq: :monthly, byday: [{-2, 5}]}, ~D[2024-01-19]),
+             4
+           ) == [
+             ~D[2024-01-19],
+             ~D[2024-02-16],
+             ~D[2024-03-22],
+             ~D[2024-04-19]
            ]
 
     # Monthly BYDAY: first Monday every 2 months
@@ -518,6 +552,31 @@ defmodule CalendarRecurrence.RRULETest do
              ~D[2025-02-03]
            ]
 
+    # Monthly BYDAY: ordinal with count
+    assert Enum.to_list(
+             RRULE.to_recurrence(
+               %RRULE{freq: :monthly, byday: [{1, 1}], count: 4},
+               ~D[2024-01-01]
+             )
+           ) == [
+             ~D[2024-01-01],
+             ~D[2024-02-05],
+             ~D[2024-03-04],
+             ~D[2024-04-01]
+           ]
+
+    # Monthly BYDAY: ordinal with until
+    assert Enum.to_list(
+             RRULE.to_recurrence(
+               %RRULE{freq: :monthly, byday: [{1, 1}], until: ~D[2024-03-04]},
+               ~D[2024-01-01]
+             )
+           ) == [
+             ~D[2024-01-01],
+             ~D[2024-02-05],
+             ~D[2024-03-04]
+           ]
+
     # Monthly BYDAY: every Monday of every month (plain, no ordinal)
     assert Enum.take(
              RRULE.to_recurrence(%RRULE{freq: :monthly, byday: [1]}, ~D[2024-01-01]),
@@ -529,6 +588,55 @@ defmodule CalendarRecurrence.RRULETest do
              ~D[2024-01-22],
              ~D[2024-01-29],
              ~D[2024-02-05]
+           ]
+
+    # Monthly BYDAY: every Monday with DateTime
+    assert Enum.take(
+             RRULE.to_recurrence(
+               %RRULE{freq: :monthly, byday: [1]},
+               ~U[2024-01-01 10:00:00Z]
+             ),
+             3
+           ) == [
+             ~U[2024-01-01 10:00:00Z],
+             ~U[2024-01-08 10:00:00Z],
+             ~U[2024-01-15 10:00:00Z]
+           ]
+
+    # Monthly BYDAY: every Monday and Friday of every month
+    assert Enum.take(
+             RRULE.to_recurrence(%RRULE{freq: :monthly, byday: [1, 5]}, ~D[2024-01-01]),
+             6
+           ) == [
+             ~D[2024-01-01],
+             ~D[2024-01-05],
+             ~D[2024-01-08],
+             ~D[2024-01-12],
+             ~D[2024-01-15],
+             ~D[2024-01-19]
+           ]
+
+    # Monthly BYDAY: every Monday every 2 months (plain with interval)
+    assert Enum.take(
+             RRULE.to_recurrence(
+               %RRULE{freq: :monthly, interval: 2, byday: [1]},
+               ~D[2024-01-29]
+             ),
+             3
+           ) == [
+             ~D[2024-01-29],
+             ~D[2024-03-04],
+             ~D[2024-03-11]
+           ]
+
+    # Monthly BYDAY: plain BYDAY year boundary
+    assert Enum.take(
+             RRULE.to_recurrence(%RRULE{freq: :monthly, byday: [1]}, ~D[2024-12-30]),
+             3
+           ) == [
+             ~D[2024-12-30],
+             ~D[2025-01-06],
+             ~D[2025-01-13]
            ]
 
     # Monthly BYDAY: multiple ordinal entries (first Monday and last Friday)


### PR DESCRIPTION
## Adds monthly BYDAY support with ordinal prefixes (#13)

**NOTE:**  PR seems large, but 3000+ lines are auto-generated by `mix compile.rrule` the majority of the remaining code are tests and documentation.

### Summary

  - Add BYDAY support for FREQ=MONTHLY per RFC 5545, enabling rules like "first Monday of every month" (BYDAY=1MO) and "last Friday of every month" (BYDAY=-1FR) as well as complex expressions like (FREQ=YEARLY;BYMONTH=3;BYDAY=2SU) -> The second Sunday of March every year.
  - Support both ordinal BYDAY (specific occurrence) and plain BYDAY (every occurrence of a weekday in each month)
  - Extend parser, step functions, String.Chars, and documentation
  - User friendly errors on incorrect {ordinance, day} parameters

### Details

Adds `BYDAY` support for `FREQ=MONTHLY` per RFC 5545, enabling rules like “first Monday of every month” or “last Friday of every month”.

Dates are represented either by list where the number is the day for expressions like "Every Monday of every month ". Or by a tuple where the first element is the nth day in the month and second the day of the week, for example `{ -1, 5 }` is "Last Friday of every month", multiple values can be provided per list for more complex expressions.

i.e.

| RRULE string      | Parsed value            | Meaning                             |
|-------------------|-------------------------|-------------------------------------|
| `BYDAY=MO`        | `[1]`                   | Every Monday of every month         |
| `BYDAY=1MO`       | `[{1, 1}]`              | First Monday of every month         |
| `BYDAY=-1FR`      | `[{ -1, 5 }]`           | Last Friday of every month          |
| `BYDAY=+2SU`      | `[{ 2, 7 }]`            | Second Sunday of every month        |
| `BYDAY=1MO,-1FR`  | `[{ 1, 1 }, { -1, 5 }]` | First Monday and last Friday        |

- Plain weekday (`MO`) → applies to every occurrence of that weekday in the month.
- Ordinal + weekday (`1MO`, `-1FR`, `+2SU`) → applies to the *nth* occurrence of that weekday in the month.